### PR TITLE
[ECO-5328] Implement initial structure of plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ docs-coverage-report
 
 /node_modules
 /.mint
+
+# User-created file that contains their Ably API key
+/Example/AblyLiveObjectsExample/Secrets.swift

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "Tests/AblyLiveObjectsTests/ably-common"]
 	path = Tests/AblyLiveObjectsTests/ably-common
 	url = https://github.com/ably/ably-common
+[submodule "ably-cocoa"]
+	path = ably-cocoa
+	url = git@github.com:ably/ably-cocoa.git

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@
 
 # Submodules
 Tests/AblyLiveObjectsTests/ably-common
+ably-cocoa

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,2 @@
+# Submodules
+--exclude ably-cocoa

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,5 +1,7 @@
 excluded:
   - .build
+  # Submodules
+  - ably-cocoa
 
 strict: true
 

--- a/AblyLiveObjects.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AblyLiveObjects.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,15 +1,6 @@
 {
-  "originHash" : "a67c16228290f1b8c671d836ff39d317eedc33a6344ba3a66295d1127aa6241a",
+  "originHash" : "6884be3a1fb838d3f9a3288b0cb994d0dfce4e90c7d648bca08e61fb802c9cda",
   "pins" : [
-    {
-      "identity" : "ably-cocoa",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ably/ably-cocoa",
-      "state" : {
-        "revision" : "c5347707e4f9fb907df0e5c334de445899a79783",
-        "version" : "1.2.40"
-      }
-    },
     {
       "identity" : "delta-codec-cocoa",
       "kind" : "remoteSourceControl",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,12 @@ Example:
 // @specNotApplicable CHA-EX3a - Our API does not have a concept of "partial options" unlike the JS API which this spec item considers.
 ```
 
+## Developing ably-cocoa alongside this plugin
+
+For the initial stage of development of this plugin, where we need to also iterate heavily on ably-cocoa, I've added ably-cocoa as a Git submodule, which can be found in [`ably-cocoa`](./ably-cocoa). This allows you to edit ably-cocoa from within this repo's Xcode workspace.
+
+Nearer launch, we'll remove this submodule in https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/7.
+
 ## Release process
 
 For each release, the following needs to be done:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,8 @@ To check formatting and code quality, run `swift run BuildTool lint`. Run with `
 
 - The public API of the SDK should use typed throws, and the thrown errors should be of type `ARTErrorInfo`.
 
+### Testing guidelines
+
 #### Attributing tests to a spec point
 
 When writing a test that relates to a spec point from the LiveObjects features spec, add a comment that contains one of the following tags:

--- a/Example/AblyLiveObjectsExample/AblyLiveObjectsExampleApp.swift
+++ b/Example/AblyLiveObjectsExample/AblyLiveObjectsExampleApp.swift
@@ -1,10 +1,19 @@
+import Ably
+import AblyLiveObjects
 import SwiftUI
 
 @main
 struct AblyLiveObjectsExampleApp: App {
+    @State private var realtime = {
+        let clientOptions = ARTClientOptions(key: Secrets.ablyAPIKey)
+        clientOptions.plugins = [.liveObjects: AblyLiveObjects.Plugin.self]
+
+        return ARTRealtime(options: clientOptions)
+    }()
+
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ContentView(realtime: realtime)
         }
     }
 }

--- a/Example/AblyLiveObjectsExample/ContentView.swift
+++ b/Example/AblyLiveObjectsExample/ContentView.swift
@@ -1,9 +1,9 @@
+import Ably
 import AblyLiveObjects
 import SwiftUI
 
 struct ContentView: View {
-    /// Just used to check that we can successfully import and use the AblyLiveObjects library. TODO remove this once we start building the library
-    @State private var ablyLiveObjectsClient = AblyLiveObjectsClient()
+    var realtime: ARTRealtime
 
     var body: some View {
         VStack {
@@ -11,11 +11,10 @@ struct ContentView: View {
                 .imageScale(.large)
                 .foregroundStyle(.tint)
             Text("Hello, world!")
+
+            let channel = realtime.channels.get("myChannel")
+            Text("`channel.objects`: `\(String(describing: channel.objects))`")
         }
         .padding()
     }
-}
-
-#Preview {
-    ContentView()
 }

--- a/Example/AblyLiveObjectsExample/Secrets.example.swift
+++ b/Example/AblyLiveObjectsExample/Secrets.example.swift
@@ -1,0 +1,9 @@
+// 1. Create a copy of this file named Secrets.swift. (Secrets.swift is included in .gitignore, to stop you from accidentally checking it in.)
+// 2. In Secrets.swift, uncomment the `Secrets` enum below.
+// 3. In Secrets.swift, insert your Ably API key in the double quotes.
+/*
+ enum Secrets {
+     // Insert your Ably API key inside the double quotes below.
+     static let ablyAPIKey = ""
+ }
+ */

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,15 +1,6 @@
 {
-  "originHash" : "334ffa0bc53636f87e6002c166aa5b75c3bd633c67ad43e001ee31ab03f11e2b",
+  "originHash" : "9d42be7ef9d81adeb6ac28ccc2a7a4dd43dbf0d952b6f8331e73ab665d36df3a",
   "pins" : [
-    {
-      "identity" : "ably-cocoa",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ably/ably-cocoa",
-      "state" : {
-        "revision" : "c5347707e4f9fb907df0e5c334de445899a79783",
-        "version" : "1.2.40"
-      }
-    },
     {
       "identity" : "delta-codec-cocoa",
       "kind" : "remoteSourceControl",

--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,7 @@ let package = Package(
     ],
     dependencies: [
         .package(
-            url: "https://github.com/ably/ably-cocoa",
-            from: "1.2.40",
+            path: "ably-cocoa",
         ),
         .package(
             url: "https://github.com/apple/swift-argument-parser",

--- a/Package.swift
+++ b/Package.swift
@@ -46,6 +46,10 @@ let package = Package(
                     name: "Ably",
                     package: "ably-cocoa",
                 ),
+                .product(
+                    name: "AblyPlugin",
+                    package: "ably-cocoa",
+                ),
             ],
         ),
         .testTarget(

--- a/README.md
+++ b/README.md
@@ -12,6 +12,25 @@ This is a work in progress plugin that enables LiveObjects functionality in the 
 
 Xcode 16.3 or later.
 
+## Installation
+
+For now, here is a code snippet demonstrating how, after installing this package and ably-cocoa using Swift Package Manager, you can set up the LiveObjects plugin and access its functionality.
+
+```swift
+import Ably
+import AblyLiveObjects
+
+let clientOptions = ARTClientOptions(key: /* <insert your Ably API key here> */)
+clientOptions.plugins = [.liveObjects: AblyLiveObjects.Plugin.self]
+
+let realtime = ARTRealtime(options: clientOptions)
+
+// You can now access LiveObjects functionality via a channel's `objects` property:
+let channel = realtime.channels.get("myChannel")
+let rootObject = try await channel.objects.getRoot()
+// …and so on
+```
+
 ## Example app
 
 This repository contains an example app, written using SwiftUI, which demonstrates how to use the SDK. The code for this app is in the [`Example`](Example) directory.
@@ -22,7 +41,11 @@ In order to allow the app to use modern SwiftUI features, it supports the follow
 - iOS 17 and above
 - tvOS 17 and above
 
-To run the app, open the `AblyLiveObjects.xcworkspace` workspace in Xcode and run the `AblyLiveObjectsExample` target. If you wish to run it on an iOS or tvOS device, you’ll need to set up code signing.
+To run the app:
+
+1. Open the `AblyLiveObjects.xcworkspace` workspace in Xcode.
+2. Follow the instructions inside the `Secrets.example.swift` file to add your Ably API key to the example app.
+3. Run the `AblyLiveObjectsExample` target. If you wish to run it on an iOS or tvOS device, you’ll need to set up code signing.
 
 ## Contributing
 

--- a/Sources/AblyLiveObjects/AblyLiveObjects.swift
+++ b/Sources/AblyLiveObjects/AblyLiveObjects.swift
@@ -1,5 +1,0 @@
-// Placeholder file.
-
-public class AblyLiveObjectsClient {
-    public init() {}
-}

--- a/Sources/AblyLiveObjects/DefaultLiveObjects.swift
+++ b/Sources/AblyLiveObjects/DefaultLiveObjects.swift
@@ -1,0 +1,49 @@
+import Ably
+internal import AblyPlugin
+
+/// The class that provides the public API for interacting with LiveObjects, via the ``ARTRealtimeChannel/objects`` property.
+internal class DefaultLiveObjects: Objects {
+    private weak var channel: ARTRealtimeChannel?
+    private let logger: AblyPlugin.Logger
+    private let pluginAPI: AblyPlugin.PluginAPIProtocol
+
+    internal init(channel: ARTRealtimeChannel, logger: AblyPlugin.Logger, pluginAPI: AblyPlugin.PluginAPIProtocol) {
+        self.channel = channel
+        self.logger = logger
+        self.pluginAPI = pluginAPI
+    }
+
+    // MARK: `Objects` protocol
+
+    internal func getRoot() async throws(ARTErrorInfo) -> any LiveMap {
+        notYetImplemented()
+    }
+
+    internal func createMap(entries _: any LiveMap) async throws(ARTErrorInfo) -> any LiveMap {
+        notYetImplemented()
+    }
+
+    internal func createMap() async throws(ARTErrorInfo) -> any LiveMap {
+        notYetImplemented()
+    }
+
+    internal func createCounter(count _: Int) async throws(ARTErrorInfo) -> any LiveCounter {
+        notYetImplemented()
+    }
+
+    internal func createCounter() async throws(ARTErrorInfo) -> any LiveCounter {
+        notYetImplemented()
+    }
+
+    internal func batch(callback _: (any BatchContext) -> Void) async throws {
+        notYetImplemented()
+    }
+
+    internal func on(event _: ObjectsEvent, callback _: () -> Void) -> any OnObjectsEventResponse {
+        notYetImplemented()
+    }
+
+    internal func offAll() {
+        notYetImplemented()
+    }
+}

--- a/Sources/AblyLiveObjects/Internal/DefaultInternalPlugin.swift
+++ b/Sources/AblyLiveObjects/Internal/DefaultInternalPlugin.swift
@@ -1,0 +1,43 @@
+internal import AblyPlugin
+
+// We explicitly import the NSObject class, else it seems to get transitively imported from  `internal import AblyPlugin`, leading to the error "Class cannot be declared public because its superclass is internal".
+import ObjectiveC.NSObject
+
+/// The default implementation of `AblyPlugin`'s `LiveObjectsInternalPluginProtocol`. Implements the interface that ably-cocoa uses to access the functionality provided by the LiveObjects plugin.
+@objc
+internal final class DefaultInternalPlugin: NSObject, AblyPlugin.LiveObjectsInternalPluginProtocol {
+    private let pluginAPI: AblyPlugin.PluginAPIProtocol
+
+    internal init(pluginAPI: AblyPlugin.PluginAPIProtocol) {
+        self.pluginAPI = pluginAPI
+    }
+
+    // MARK: - Channel `objects` property
+
+    /// The `pluginDataValue(forKey:channel:)` key that we use to store the value of the `ARTRealtimeChannel.objects` property.
+    private static let pluginDataKey = "LiveObjects"
+
+    /// Retrieves the value that should be returned by `ARTRealtimeChannel.objects`.
+    ///
+    /// We expect this value to have been previously set by ``prepare(_:)``.
+    internal static func objectsProperty(for channel: ARTRealtimeChannel, pluginAPI: AblyPlugin.PluginAPIProtocol) -> DefaultLiveObjects {
+        guard let pluginData = pluginAPI.pluginDataValue(forKey: pluginDataKey, channel: channel) else {
+            // InternalPlugin.prepare was not called
+            fatalError("To access LiveObjects functionality, you must pass the LiveObjects plugin in the client options when creating the ARTRealtime instance: `clientOptions.plugins = [.liveObjects: AblyLiveObjects.Plugin.self]`")
+        }
+
+        // swiftlint:disable:next force_cast
+        return pluginData as! DefaultLiveObjects
+    }
+
+    // MARK: - LiveObjectsInternalPluginProtocol
+
+    // Populates the channel's `objects` property.
+    internal func prepare(_ channel: ARTRealtimeChannel) {
+        let logger = pluginAPI.logger(for: channel)
+
+        logger.log("LiveObjects.DefaultInternalPlugin received prepare(_:)", level: .debug)
+        let liveObjects = DefaultLiveObjects(channel: channel, logger: logger, pluginAPI: pluginAPI)
+        pluginAPI.setPluginDataValue(liveObjects, forKey: Self.pluginDataKey, channel: channel)
+    }
+}

--- a/Sources/AblyLiveObjects/Public/ARTRealtimeChannel+Objects.swift
+++ b/Sources/AblyLiveObjects/Public/ARTRealtimeChannel+Objects.swift
@@ -1,8 +1,9 @@
 import Ably
+internal import AblyPlugin
 
 public extension ARTRealtimeChannel {
     /// An ``Objects`` object.
     var objects: Objects {
-        notYetImplemented()
+        DefaultInternalPlugin.objectsProperty(for: self, pluginAPI: AblyPlugin.PluginAPI.sharedInstance())
     }
 }

--- a/Sources/AblyLiveObjects/Public/Plugin.swift
+++ b/Sources/AblyLiveObjects/Public/Plugin.swift
@@ -1,0 +1,28 @@
+internal import AblyPlugin
+
+// We explicitly import the NSObject class, else it seems to get transitively imported from  `internal import AblyPlugin`, leading to the error "Class cannot be declared public because its superclass is internal".
+import ObjectiveC.NSObject
+
+/// This plugin enables LiveObjects functionality in ably-cocoa. Set the `.liveObjects` key in the ably-cocoa `plugins` client option to this class in order to enable LiveObjects.
+///
+/// For example:
+/// ```swift
+/// import Ably
+/// import AblyLiveObjects
+///
+/// let clientOptions = ARTClientOptions(key: /* <insert your Ably API key here> */)
+/// clientOptions.plugins = [.liveObjects: AblyLiveObjects.Plugin.self]
+///
+/// let realtime = ARTRealtime(options: clientOptions)
+///
+/// // You can now access LiveObjects functionality via a channel's `objects` property:
+/// let channel = realtime.channels.get("myChannel")
+/// let rootObject = try await channel.objects.getRoot()
+/// // …and so on
+/// ```
+@objc
+public class Plugin: NSObject {
+    // MARK: - Informal conformance to AblyPlugin.LiveObjectsPluginProtocol
+
+    @objc private static let internalPlugin = DefaultInternalPlugin(pluginAPI: AblyPlugin.PluginAPI.sharedInstance())
+}

--- a/Sources/AblyLiveObjects/Utility/APLogger+Swift.swift
+++ b/Sources/AblyLiveObjects/Utility/APLogger+Swift.swift
@@ -1,0 +1,8 @@
+internal import AblyPlugin
+
+internal extension AblyPlugin.Logger {
+    /// A convenience method that provides default values for `file` and `line`.
+    func log(_ message: String, level: ARTLogLevel, fileID: String = #fileID, line: Int = #line) {
+        log(message, with: level, file: fileID, line: line)
+    }
+}

--- a/Sources/BuildTool/BuildTool.swift
+++ b/Sources/BuildTool/BuildTool.swift
@@ -106,6 +106,20 @@ struct BuildExampleApp: AsyncParsableCommand {
     mutating func run() async throws {
         let destinationSpecifier = try await platform.resolve()
 
+        let secretsFilePath = "Example/AblyLiveObjectsExample/Secrets.swift"
+        if !FileManager.default.fileExists(atPath: secretsFilePath) {
+            // If it doesn't already exist (e.g. if running in CI), create the Secrets.swift file needed to build the example app
+            let secretsFileContents = """
+            enum Secrets {
+                // Insert your Ably API key inside the double quotes below.
+                static let ablyAPIKey = ""
+            }
+            """
+
+            let data = secretsFileContents.data(using: .utf8)!
+            try data.write(to: .init(filePath: secretsFilePath))
+        }
+
         try await XcodeRunner.runXcodebuild(action: nil, scheme: "AblyLiveObjectsExample", destination: destinationSpecifier)
     }
 }

--- a/Tests/AblyLiveObjectsTests/AblyLiveObjectsTests.swift
+++ b/Tests/AblyLiveObjectsTests/AblyLiveObjectsTests.swift
@@ -1,8 +1,24 @@
+import Ably
+@testable import AblyLiveObjects
 import Testing
 
 struct AblyLiveObjectsTests {
     @Test
-    func example() {
-        // just to get code-coverage task passing
+    func objectsProperty() async throws {
+        // Given
+
+        let clientOptions = ARTClientOptions(key: "foo:bar")
+        clientOptions.plugins = [.liveObjects: AblyLiveObjects.Plugin.self]
+        // Don't need to connect
+        clientOptions.autoConnect = false
+
+        let realtime = ARTRealtime(options: clientOptions)
+
+        let channel = realtime.channels.get("someChannel")
+
+        // Then
+
+        // Check that the `channel.objects` property works and gives the internal type we expect
+        #expect(channel.objects is DefaultLiveObjects)
     }
 }


### PR DESCRIPTION
This implements the plugin structure described in [ADR-128: Plugins for ably-cocoa SDK](https://ably.atlassian.net/wiki/spaces/ENG/pages/3838574593/ADR-128+Plugins+for+ably-cocoa+SDK). It makes use of the plugins mechanism added to ably-cocoa in https://github.com/ably/ably-cocoa/pull/2053.

It provides the implementation of the `ARTRealtimeChannel.objects` property (but does not implement any of this object's functionality) and demonstrates how to use the logging functionality exposed by ably-cocoa via its plugins API.