### PR TITLE
[ECO-5328] Further initial setup of plugin

### DIFF
--- a/Sources/AblyLiveObjects/DefaultLiveObjects.swift
+++ b/Sources/AblyLiveObjects/DefaultLiveObjects.swift
@@ -46,4 +46,18 @@ internal class DefaultLiveObjects: Objects {
     internal func offAll() {
         notYetImplemented()
     }
+
+    // MARK: Handling channel events
+
+    internal func onChannelAttached(hasObjects _: Bool) {
+        notYetImplemented()
+    }
+
+    internal func handleObjectProtocolMessage(objectMessages _: [ObjectMessage]) {
+        notYetImplemented()
+    }
+
+    internal func handleObjectSyncProtocolMessage(objectMessages _: [ObjectMessage], protocolMessageChannelSerial _: String) {
+        notYetImplemented()
+    }
 }

--- a/Sources/AblyLiveObjects/Internal/DefaultInternalPlugin.swift
+++ b/Sources/AblyLiveObjects/Internal/DefaultInternalPlugin.swift
@@ -40,4 +40,63 @@ internal final class DefaultInternalPlugin: NSObject, AblyPlugin.LiveObjectsInte
         let liveObjects = DefaultLiveObjects(channel: channel, logger: logger, pluginAPI: pluginAPI)
         pluginAPI.setPluginDataValue(liveObjects, forKey: Self.pluginDataKey, channel: channel)
     }
+
+    /// Retrieves the internally-typed `objects` property for the channel.
+    private func objectsProperty(for channel: ARTRealtimeChannel) -> DefaultLiveObjects {
+        Self.objectsProperty(for: channel, pluginAPI: pluginAPI)
+    }
+
+    /// A class that wraps an ``ObjectMessage``.
+    ///
+    /// We need this intermediate type because we want `ObjectMessage` to be a struct — because it's nicer to work with internally — but a struct can't conform to the class-bound `AblyPlugin.ObjectMessage` protocol.
+    private final class ObjectMessageBox: AblyPlugin.ObjectMessageProtocol {
+        internal let objectMessage: ObjectMessage
+
+        init(objectMessage: ObjectMessage) {
+            self.objectMessage = objectMessage
+        }
+    }
+
+    internal func decodeObjectMessage(_: [AnyHashable: Any]) -> any AblyPlugin.ObjectMessageProtocol {
+        // TODO: do something with the dictionary
+        let objectMessage = ObjectMessage()
+        return ObjectMessageBox(objectMessage: objectMessage)
+    }
+
+    internal func encodeObjectMessage(_ publicObjectMessage: any AblyPlugin.ObjectMessageProtocol) -> [AnyHashable: Any] {
+        guard publicObjectMessage is ObjectMessageBox else {
+            preconditionFailure("Expected to receive the same ObjectMessage type as we emit")
+        }
+
+        notYetImplemented()
+    }
+
+    internal func onChannelAttached(_ channel: ARTRealtimeChannel, hasObjects: Bool) {
+        objectsProperty(for: channel).onChannelAttached(hasObjects: hasObjects)
+    }
+
+    internal func handleObjectProtocolMessage(withObjectMessages publicObjectMessages: [any AblyPlugin.ObjectMessageProtocol], channel: ARTRealtimeChannel) {
+        guard let objectMessageBoxes = publicObjectMessages as? [ObjectMessageBox] else {
+            preconditionFailure("Expected to receive the same ObjectMessage type as we emit")
+        }
+
+        let objectMessages = objectMessageBoxes.map(\.objectMessage)
+
+        objectsProperty(for: channel).handleObjectProtocolMessage(
+            objectMessages: objectMessages,
+        )
+    }
+
+    internal func handleObjectSyncProtocolMessage(withObjectMessages publicObjectMessages: [any AblyPlugin.ObjectMessageProtocol], protocolMessageChannelSerial: String, channel: ARTRealtimeChannel) {
+        guard let objectMessageBoxes = publicObjectMessages as? [ObjectMessageBox] else {
+            preconditionFailure("Expected to receive the same ObjectMessage type as we emit")
+        }
+
+        let objectMessages = objectMessageBoxes.map(\.objectMessage)
+
+        objectsProperty(for: channel).handleObjectSyncProtocolMessage(
+            objectMessages: objectMessages,
+            protocolMessageChannelSerial: protocolMessageChannelSerial,
+        )
+    }
 }

--- a/Sources/AblyLiveObjects/Protocol/ObjectMessage.swift
+++ b/Sources/AblyLiveObjects/Protocol/ObjectMessage.swift
@@ -1,0 +1,2 @@
+/// An `ObjectMessage` received in the `state` property of an `OBJECT` or `OBJECT_SYNC` `ProtocolMessage`.
+internal struct ObjectMessage {}


### PR DESCRIPTION
Adds empty implementations of the API that the LiveObjects plugin must implement, as added in ably-cocoa commit `dcca250`. We'll implement these methods, and refine their meaning, later.

Demonstrates how the calls to the plugin API find their way to the `DefaultLiveObjects` object, and how we convert the `ObjectMessage` type that we emit to ably-cocoa into the nice Swift struct that we'll use internally.