### PR TITLE
[ECO-5333] Apply `OBJECT` `ProtocolMessage` operations

### DIFF
--- a/Sources/AblyLiveObjects/DefaultRealtimeObjects.swift
+++ b/Sources/AblyLiveObjects/DefaultRealtimeObjects.swift
@@ -73,7 +73,7 @@ internal final class DefaultRealtimeObjects: RealtimeObjects, LiveMapObjectPoolD
         (receivedObjectProtocolMessages, receivedObjectProtocolMessagesContinuation) = AsyncStream.makeStream()
         (receivedObjectSyncProtocolMessages, receivedObjectSyncProtocolMessagesContinuation) = AsyncStream.makeStream()
         (waitingForSyncEvents, waitingForSyncEventsContinuation) = AsyncStream.makeStream()
-        mutableState = .init(objectsPool: .init(rootDelegate: self, rootCoreSDK: coreSDK))
+        mutableState = .init(objectsPool: .init(rootDelegate: self, rootCoreSDK: coreSDK, logger: logger))
     }
 
     // MARK: - LiveMapObjectPoolDelegate
@@ -193,7 +193,7 @@ internal final class DefaultRealtimeObjects: RealtimeObjects, LiveMapObjectPoolD
     /// Intended as a way for tests to populate the object pool.
     internal func testsOnly_createZeroValueLiveObject(forObjectID objectID: String, coreSDK: CoreSDK) -> ObjectsPool.Entry? {
         mutex.withLock {
-            mutableState.objectsPool.createZeroValueObject(forObjectID: objectID, mapDelegate: self, coreSDK: coreSDK)
+            mutableState.objectsPool.createZeroValueObject(forObjectID: objectID, mapDelegate: self, coreSDK: coreSDK, logger: logger)
         }
     }
 
@@ -242,7 +242,7 @@ internal final class DefaultRealtimeObjects: RealtimeObjects, LiveMapObjectPoolD
 
             // RTO4b1, RTO4b2: Reset the ObjectsPool to have a single empty root object
             // TODO: this one is unclear (are we meant to replace the root or just clear its data?) https://github.com/ably/specification/pull/333/files#r2183493458
-            objectsPool = .init(rootDelegate: mapDelegate, rootCoreSDK: coreSDK)
+            objectsPool = .init(rootDelegate: mapDelegate, rootCoreSDK: coreSDK, logger: logger)
 
             // I have, for now, not directly implemented the "perform the actions for object sync completion" of RTO4b4 since my implementation doesn't quite match the model given there; here you only have a SyncObjectsPool if you have an OBJECT_SYNC in progress, which you might not have upon receiving an ATTACHED. Instead I've just implemented what seem like the relevant side effects. Can revisit this if "the actions for object sync completion" get more complex.
 

--- a/Sources/AblyLiveObjects/Internal/DefaultLiveCounter.swift
+++ b/Sources/AblyLiveObjects/Internal/DefaultLiveCounter.swift
@@ -1,4 +1,5 @@
 import Ably
+internal import AblyPlugin
 import Foundation
 
 /// Our default implementation of ``LiveCounter``.
@@ -27,24 +28,28 @@ internal final class DefaultLiveCounter: LiveCounter {
     }
 
     private let coreSDK: CoreSDK
+    private let logger: AblyPlugin.Logger
 
     // MARK: - Initialization
 
     internal convenience init(
         testsOnly_data data: Double,
         objectID: String,
-        coreSDK: CoreSDK
+        coreSDK: CoreSDK,
+        logger: AblyPlugin.Logger
     ) {
-        self.init(data: data, objectID: objectID, coreSDK: coreSDK)
+        self.init(data: data, objectID: objectID, coreSDK: coreSDK, logger: logger)
     }
 
     private init(
         data: Double,
         objectID: String,
-        coreSDK: CoreSDK
+        coreSDK: CoreSDK,
+        logger: AblyPlugin.Logger
     ) {
         mutableState = .init(liveObject: .init(objectID: objectID), data: data)
         self.coreSDK = coreSDK
+        self.logger = logger
     }
 
     /// Creates a "zero-value LiveCounter", per RTLC4.
@@ -54,11 +59,13 @@ internal final class DefaultLiveCounter: LiveCounter {
     internal static func createZeroValued(
         objectID: String,
         coreSDK: CoreSDK,
+        logger: AblyPlugin.Logger,
     ) -> Self {
         .init(
             data: 0,
             objectID: objectID,
             coreSDK: coreSDK,
+            logger: logger,
         )
     }
 

--- a/Sources/AblyLiveObjects/Internal/DefaultLiveCounter.swift
+++ b/Sources/AblyLiveObjects/Internal/DefaultLiveCounter.swift
@@ -8,19 +8,19 @@ internal final class DefaultLiveCounter: LiveCounter {
 
     private nonisolated(unsafe) var mutableState: MutableState
 
-    internal var testsOnly_siteTimeserials: [String: String]? {
+    internal var testsOnly_siteTimeserials: [String: String] {
         mutex.withLock {
             mutableState.siteTimeserials
         }
     }
 
-    internal var testsOnly_createOperationIsMerged: Bool? {
+    internal var testsOnly_createOperationIsMerged: Bool {
         mutex.withLock {
             mutableState.createOperationIsMerged
         }
     }
 
-    internal var testsOnly_objectID: String? {
+    internal var testsOnly_objectID: String {
         mutex.withLock {
             mutableState.objectID
         }
@@ -32,7 +32,7 @@ internal final class DefaultLiveCounter: LiveCounter {
 
     internal convenience init(
         testsOnly_data data: Double,
-        objectID: String?,
+        objectID: String,
         coreSDK: CoreSDK
     ) {
         self.init(data: data, objectID: objectID, coreSDK: coreSDK)
@@ -40,7 +40,7 @@ internal final class DefaultLiveCounter: LiveCounter {
 
     private init(
         data: Double,
-        objectID: String?,
+        objectID: String,
         coreSDK: CoreSDK
     ) {
         mutableState = .init(data: data, objectID: objectID)
@@ -52,7 +52,7 @@ internal final class DefaultLiveCounter: LiveCounter {
     /// - Parameters:
     ///   - objectID: The value for the "private objectId field" of RTO5c1b1a.
     internal static func createZeroValued(
-        objectID: String? = nil,
+        objectID: String,
         coreSDK: CoreSDK,
     ) -> Self {
         .init(
@@ -123,13 +123,13 @@ internal final class DefaultLiveCounter: LiveCounter {
         internal var data: Double
 
         /// The site timeserials for this counter, per RTLC6a.
-        internal var siteTimeserials: [String: String]?
+        internal var siteTimeserials: [String: String] = [:]
 
         /// Whether the create operation has been merged, per RTLC6b and RTLC6d2.
-        internal var createOperationIsMerged: Bool?
+        internal var createOperationIsMerged = false
 
         /// The "private `objectId` field" of RTO5c1b1a.
-        internal var objectID: String?
+        internal var objectID: String
 
         /// Replaces the internal data of this counter with the provided ObjectState, per RTLC6.
         internal mutating func replaceData(using state: ObjectState) {

--- a/Sources/AblyLiveObjects/Internal/DefaultLiveMap.swift
+++ b/Sources/AblyLiveObjects/Internal/DefaultLiveMap.swift
@@ -19,7 +19,7 @@ internal final class DefaultLiveMap: LiveMap {
         }
     }
 
-    internal var testsOnly_objectID: String? {
+    internal var testsOnly_objectID: String {
         mutex.withLock {
             mutableState.objectID
         }
@@ -31,13 +31,13 @@ internal final class DefaultLiveMap: LiveMap {
         }
     }
 
-    internal var testsOnly_siteTimeserials: [String: String]? {
+    internal var testsOnly_siteTimeserials: [String: String] {
         mutex.withLock {
             mutableState.siteTimeserials
         }
     }
 
-    internal var testsOnly_createOperationIsMerged: Bool? {
+    internal var testsOnly_createOperationIsMerged: Bool {
         mutex.withLock {
             mutableState.createOperationIsMerged
         }
@@ -55,7 +55,7 @@ internal final class DefaultLiveMap: LiveMap {
 
     internal convenience init(
         testsOnly_data data: [String: ObjectsMapEntry],
-        objectID: String? = nil,
+        objectID: String,
         testsOnly_semantics semantics: WireEnum<ObjectsMapSemantics>? = nil,
         delegate: LiveMapObjectPoolDelegate?,
         coreSDK: CoreSDK
@@ -71,7 +71,7 @@ internal final class DefaultLiveMap: LiveMap {
 
     private init(
         data: [String: ObjectsMapEntry],
-        objectID: String?,
+        objectID: String,
         semantics: WireEnum<ObjectsMapSemantics>?,
         delegate: LiveMapObjectPoolDelegate?,
         coreSDK: CoreSDK
@@ -87,7 +87,7 @@ internal final class DefaultLiveMap: LiveMap {
     ///   - objectID: The value to use for the "private `objectId` field" of RTO5c1b1b.
     ///   - semantics: The value to use for the "private `semantics` field" of RTO5c1b1b.
     internal static func createZeroValued(
-        objectID: String? = nil,
+        objectID: String,
         semantics: WireEnum<ObjectsMapSemantics>? = nil,
         delegate: LiveMapObjectPoolDelegate?,
         coreSDK: CoreSDK,
@@ -275,16 +275,16 @@ internal final class DefaultLiveMap: LiveMap {
         internal var data: [String: ObjectsMapEntry]
 
         /// The "private `objectId` field" of RTO5c1b1b.
-        internal var objectID: String?
+        internal var objectID: String
 
         /// The "private `semantics` field" of RTO5c1b1b.
         internal var semantics: WireEnum<ObjectsMapSemantics>?
 
         /// The site timeserials for this map, per RTLM6a.
-        internal var siteTimeserials: [String: String]?
+        internal var siteTimeserials: [String: String] = [:]
 
         /// Whether the create operation has been merged, per RTLM6b and RTLM6d2.
-        internal var createOperationIsMerged: Bool?
+        internal var createOperationIsMerged = false
 
         /// Replaces the internal data of this map with the provided ObjectState, per RTLM6.
         ///

--- a/Sources/AblyLiveObjects/Internal/LiveObjectMutableState.swift
+++ b/Sources/AblyLiveObjects/Internal/LiveObjectMutableState.swift
@@ -1,3 +1,5 @@
+internal import AblyPlugin
+
 /// This is the equivalent of the `LiveObject` abstract class described in RTLO.
 ///
 /// ``DefaultLiveCounter`` and ``DefaultLiveMap`` include it by composition.
@@ -8,4 +10,41 @@ internal struct LiveObjectMutableState {
     internal var siteTimeserials: [String: String] = [:]
     // RTLO3c
     internal var createOperationIsMerged = false
+
+    /// Represents parameters of an operation that `canApplyOperation` has decided can be applied to a `LiveObject`.
+    ///
+    /// The key thing is that it offers a non-nil `serial` and `siteCode`, which will be needed when subsequently performing the operation.
+    internal struct ApplicableOperation: Equatable {
+        internal let objectMessageSerial: String
+        internal let objectMessageSiteCode: String
+    }
+
+    /// Indicates whether an operation described by an `ObjectMessage` should be applied or discarded, per RTLO4a.
+    ///
+    /// Instead of returning a `Bool`, in the case where the operation can be applied it returns a non-nil `ApplicableOperation` (whose non-nil `serial` and `siteCode` will be needed as part of subsequently performing this operation).
+    internal func canApplyOperation(objectMessageSerial: String?, objectMessageSiteCode: String?, logger: Logger) -> ApplicableOperation? {
+        // RTLO4a3: Both ObjectMessage.serial and ObjectMessage.siteCode must be non-empty strings
+        guard let serial = objectMessageSerial, !serial.isEmpty,
+              let siteCode = objectMessageSiteCode, !siteCode.isEmpty
+        else {
+            // RTLO4a3: Otherwise, log a warning that the object operation message has invalid serial values
+            logger.log("Object operation message has invalid serial values: serial=\(objectMessageSerial ?? "nil"), siteCode=\(objectMessageSiteCode ?? "nil")", level: .warn)
+            return nil
+        }
+
+        // RTLO4a4: Get the siteSerial value stored for this LiveObject in the siteTimeserials map using the key ObjectMessage.siteCode
+        let siteSerial = siteTimeserials[siteCode]
+
+        // RTLO4a5: If the siteSerial for this LiveObject is null or an empty string, return true
+        guard let siteSerial, !siteSerial.isEmpty else {
+            return ApplicableOperation(objectMessageSerial: serial, objectMessageSiteCode: siteCode)
+        }
+
+        // RTLO4a6: If the siteSerial for this LiveObject is not an empty string, return true if ObjectMessage.serial is greater than siteSerial when compared lexicographically
+        if serial > siteSerial {
+            return ApplicableOperation(objectMessageSerial: serial, objectMessageSiteCode: siteCode)
+        }
+
+        return nil
+    }
 }

--- a/Sources/AblyLiveObjects/Internal/LiveObjectMutableState.swift
+++ b/Sources/AblyLiveObjects/Internal/LiveObjectMutableState.swift
@@ -1,0 +1,11 @@
+/// This is the equivalent of the `LiveObject` abstract class described in RTLO.
+///
+/// ``DefaultLiveCounter`` and ``DefaultLiveMap`` include it by composition.
+internal struct LiveObjectMutableState {
+    // RTLO3a
+    internal var objectID: String
+    // RTLO3b
+    internal var siteTimeserials: [String: String] = [:]
+    // RTLO3c
+    internal var createOperationIsMerged = false
+}

--- a/Sources/AblyLiveObjects/Internal/ObjectsPool.swift
+++ b/Sources/AblyLiveObjects/Internal/ObjectsPool.swift
@@ -60,7 +60,7 @@ internal struct ObjectsPool {
     ) {
         entries = otherEntries ?? [:]
         // TODO: What initial root entry to use? https://github.com/ably/specification/pull/333/files#r2152312933
-        entries[Self.rootKey] = .map(.createZeroValued(delegate: rootDelegate, coreSDK: rootCoreSDK))
+        entries[Self.rootKey] = .map(.createZeroValued(objectID: Self.rootKey, delegate: rootDelegate, coreSDK: rootCoreSDK))
     }
 
     // MARK: - Typed root

--- a/Sources/AblyLiveObjects/Internal/ObjectsPool.swift
+++ b/Sources/AblyLiveObjects/Internal/ObjectsPool.swift
@@ -28,6 +28,31 @@ internal struct ObjectsPool {
                 counter
             }
         }
+
+        /// Applies an operation to a LiveObject, per RTO9a2a3.
+        internal func apply(
+            _ operation: ObjectOperation,
+            objectMessageSerial: String?,
+            objectMessageSiteCode: String?,
+            objectsPool: inout ObjectsPool,
+        ) {
+            switch self {
+            case let .map(map):
+                map.apply(
+                    operation,
+                    objectMessageSerial: objectMessageSerial,
+                    objectMessageSiteCode: objectMessageSiteCode,
+                    objectsPool: &objectsPool,
+                )
+            case let .counter(counter):
+                counter.apply(
+                    operation,
+                    objectMessageSerial: objectMessageSerial,
+                    objectMessageSiteCode: objectMessageSiteCode,
+                    objectsPool: &objectsPool,
+                )
+            }
+        }
     }
 
     /// Keyed by `objectId`.

--- a/Tests/AblyLiveObjectsTests/DefaultLiveCounterTests.swift
+++ b/Tests/AblyLiveObjectsTests/DefaultLiveCounterTests.swift
@@ -9,7 +9,7 @@ struct DefaultLiveCounterTests {
         // @spec RTLC5b
         @Test(arguments: [.detached, .failed] as [ARTRealtimeChannelState])
         func valueThrowsIfChannelIsDetachedOrFailed(channelState: ARTRealtimeChannelState) async throws {
-            let counter = DefaultLiveCounter.createZeroValued(coreSDK: MockCoreSDK(channelState: channelState))
+            let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: channelState))
 
             #expect {
                 _ = try counter.value
@@ -25,7 +25,7 @@ struct DefaultLiveCounterTests {
         // @spec RTLC5c
         @Test
         func valueReturnsCurrentDataWhenChannelIsValid() throws {
-            let counter = DefaultLiveCounter.createZeroValued(coreSDK: MockCoreSDK(channelState: .attached))
+            let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attached))
 
             // Set some test data
             counter.replaceData(using: TestFactories.counterObjectState(count: 42))
@@ -39,7 +39,7 @@ struct DefaultLiveCounterTests {
         // @spec RTLC6a
         @Test
         func replacesSiteTimeserials() {
-            let counter = DefaultLiveCounter.createZeroValued(coreSDK: MockCoreSDK(channelState: .attaching))
+            let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attaching))
             let state = TestFactories.counterObjectState(
                 siteTimeserials: ["site1": "ts1"], // Test value
             )
@@ -52,18 +52,35 @@ struct DefaultLiveCounterTests {
             // @spec RTLC6b - Tests the case without createOp, as RTLC6d2 takes precedence when createOp exists
             @Test
             func setsCreateOperationIsMergedToFalse() {
-                let counter = DefaultLiveCounter.createZeroValued(coreSDK: MockCoreSDK(channelState: .attaching))
+                // Given: A counter whose createOperationIsMerged is true
+                let counter = {
+                    let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attaching))
+                    // Test setup: Manipulate counter so that its createOperationIsMerged gets set to true (we need to do this since we want to later assert that it gets set to false, but the default is false).
+                    let state = TestFactories.counterObjectState(
+                        createOp: TestFactories.objectOperation(
+                            action: .known(.counterCreate),
+                        ),
+                    )
+                    counter.replaceData(using: state)
+                    #expect(counter.testsOnly_createOperationIsMerged)
+
+                    return counter
+                }()
+
+                // When:
                 let state = TestFactories.counterObjectState(
                     createOp: nil, // Test value - must be nil to test RTLC6b
                 )
                 counter.replaceData(using: state)
-                #expect(counter.testsOnly_createOperationIsMerged == false)
+
+                // Then:
+                #expect(!counter.testsOnly_createOperationIsMerged)
             }
 
             // @specOneOf(1/4) RTLC6c - count but no createOp
             @Test
             func setsDataToCounterCount() throws {
-                let counter = DefaultLiveCounter.createZeroValued(coreSDK: MockCoreSDK(channelState: .attaching))
+                let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attaching))
                 let state = TestFactories.counterObjectState(
                     count: 42, // Test value
                 )
@@ -74,7 +91,7 @@ struct DefaultLiveCounterTests {
             // @specOneOf(2/4) RTLC6c - no count, no createOp
             @Test
             func setsDataToZeroWhenCounterCountDoesNotExist() throws {
-                let counter = DefaultLiveCounter.createZeroValued(coreSDK: MockCoreSDK(channelState: .attaching))
+                let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attaching))
                 counter.replaceData(using: TestFactories.counterObjectState(
                     count: nil, // Test value - must be nil
                 ))
@@ -88,7 +105,7 @@ struct DefaultLiveCounterTests {
             // @specOneOf(3/4) RTLC6c - count and createOp
             @Test
             func setsDataToCounterCountThenAddsCreateOpCounterCount() throws {
-                let counter = DefaultLiveCounter.createZeroValued(coreSDK: MockCoreSDK(channelState: .attaching))
+                let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attaching))
                 let state = TestFactories.counterObjectState(
                     createOp: TestFactories.counterCreateOperation(count: 10), // Test value - must exist
                     count: 5, // Test value - must exist
@@ -101,7 +118,7 @@ struct DefaultLiveCounterTests {
             // @specOneOf(4/4) RTLC6c - no count but createOp
             @Test
             func doesNotModifyDataWhenCreateOpCounterCountDoesNotExist() throws {
-                let counter = DefaultLiveCounter.createZeroValued(coreSDK: MockCoreSDK(channelState: .attaching))
+                let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attaching))
                 let state = TestFactories.counterObjectState(
                     createOp: TestFactories.objectOperation(
                         action: .known(.counterCreate),
@@ -116,14 +133,14 @@ struct DefaultLiveCounterTests {
             // @spec RTLC6d2
             @Test
             func setsCreateOperationIsMergedToTrue() {
-                let counter = DefaultLiveCounter.createZeroValued(coreSDK: MockCoreSDK(channelState: .attaching))
+                let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attaching))
                 let state = TestFactories.counterObjectState(
                     createOp: TestFactories.objectOperation( // Test value - must be non-nil
                         action: .known(.counterCreate),
                     ),
                 )
                 counter.replaceData(using: state)
-                #expect(counter.testsOnly_createOperationIsMerged == true)
+                #expect(counter.testsOnly_createOperationIsMerged)
             }
         }
     }

--- a/Tests/AblyLiveObjectsTests/DefaultLiveCounterTests.swift
+++ b/Tests/AblyLiveObjectsTests/DefaultLiveCounterTests.swift
@@ -9,7 +9,8 @@ struct DefaultLiveCounterTests {
         // @spec RTLC5b
         @Test(arguments: [.detached, .failed] as [ARTRealtimeChannelState])
         func valueThrowsIfChannelIsDetachedOrFailed(channelState: ARTRealtimeChannelState) async throws {
-            let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: channelState))
+            let logger = TestLogger()
+            let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: channelState), logger: logger)
 
             #expect {
                 _ = try counter.value
@@ -25,7 +26,8 @@ struct DefaultLiveCounterTests {
         // @spec RTLC5c
         @Test
         func valueReturnsCurrentDataWhenChannelIsValid() throws {
-            let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attached))
+            let logger = TestLogger()
+            let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attached), logger: logger)
 
             // Set some test data
             counter.replaceData(using: TestFactories.counterObjectState(count: 42))
@@ -39,7 +41,8 @@ struct DefaultLiveCounterTests {
         // @spec RTLC6a
         @Test
         func replacesSiteTimeserials() {
-            let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attaching))
+            let logger = TestLogger()
+            let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attaching), logger: logger)
             let state = TestFactories.counterObjectState(
                 siteTimeserials: ["site1": "ts1"], // Test value
             )
@@ -53,8 +56,9 @@ struct DefaultLiveCounterTests {
             @Test
             func setsCreateOperationIsMergedToFalse() {
                 // Given: A counter whose createOperationIsMerged is true
+                let logger = TestLogger()
                 let counter = {
-                    let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attaching))
+                    let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attaching), logger: logger)
                     // Test setup: Manipulate counter so that its createOperationIsMerged gets set to true (we need to do this since we want to later assert that it gets set to false, but the default is false).
                     let state = TestFactories.counterObjectState(
                         createOp: TestFactories.objectOperation(
@@ -80,7 +84,8 @@ struct DefaultLiveCounterTests {
             // @specOneOf(1/4) RTLC6c - count but no createOp
             @Test
             func setsDataToCounterCount() throws {
-                let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attaching))
+                let logger = TestLogger()
+                let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attaching), logger: logger)
                 let state = TestFactories.counterObjectState(
                     count: 42, // Test value
                 )
@@ -91,7 +96,8 @@ struct DefaultLiveCounterTests {
             // @specOneOf(2/4) RTLC6c - no count, no createOp
             @Test
             func setsDataToZeroWhenCounterCountDoesNotExist() throws {
-                let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attaching))
+                let logger = TestLogger()
+                let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attaching), logger: logger)
                 counter.replaceData(using: TestFactories.counterObjectState(
                     count: nil, // Test value - must be nil
                 ))
@@ -105,7 +111,8 @@ struct DefaultLiveCounterTests {
             // @specOneOf(3/4) RTLC6c - count and createOp
             @Test
             func setsDataToCounterCountThenAddsCreateOpCounterCount() throws {
-                let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attaching))
+                let logger = TestLogger()
+                let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attaching), logger: logger)
                 let state = TestFactories.counterObjectState(
                     createOp: TestFactories.counterCreateOperation(count: 10), // Test value - must exist
                     count: 5, // Test value - must exist
@@ -118,7 +125,8 @@ struct DefaultLiveCounterTests {
             // @specOneOf(4/4) RTLC6c - no count but createOp
             @Test
             func doesNotModifyDataWhenCreateOpCounterCountDoesNotExist() throws {
-                let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attaching))
+                let logger = TestLogger()
+                let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attaching), logger: logger)
                 let state = TestFactories.counterObjectState(
                     createOp: TestFactories.objectOperation(
                         action: .known(.counterCreate),
@@ -133,7 +141,8 @@ struct DefaultLiveCounterTests {
             // @spec RTLC6d2
             @Test
             func setsCreateOperationIsMergedToTrue() {
-                let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attaching))
+                let logger = TestLogger()
+                let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attaching), logger: logger)
                 let state = TestFactories.counterObjectState(
                     createOp: TestFactories.objectOperation( // Test value - must be non-nil
                         action: .known(.counterCreate),

--- a/Tests/AblyLiveObjectsTests/DefaultLiveMapTests.swift
+++ b/Tests/AblyLiveObjectsTests/DefaultLiveMapTests.swift
@@ -9,7 +9,7 @@ struct DefaultLiveMapTests {
         // @spec RTLM5c
         @Test(arguments: [.detached, .failed] as [ARTRealtimeChannelState])
         func getThrowsIfChannelIsDetachedOrFailed(channelState: ARTRealtimeChannelState) async throws {
-            let map = DefaultLiveMap.createZeroValued(delegate: MockLiveMapObjectPoolDelegate(), coreSDK: MockCoreSDK(channelState: channelState))
+            let map = DefaultLiveMap.createZeroValued(objectID: "arbitrary", delegate: MockLiveMapObjectPoolDelegate(), coreSDK: MockCoreSDK(channelState: channelState))
 
             #expect {
                 _ = try map.get(key: "test")
@@ -28,7 +28,7 @@ struct DefaultLiveMapTests {
         @Test
         func returnsNilWhenNoEntryExists() throws {
             let coreSDK = MockCoreSDK(channelState: .attaching)
-            let map = DefaultLiveMap.createZeroValued(delegate: MockLiveMapObjectPoolDelegate(), coreSDK: coreSDK)
+            let map = DefaultLiveMap.createZeroValued(objectID: "arbitrary", delegate: MockLiveMapObjectPoolDelegate(), coreSDK: coreSDK)
             #expect(try map.get(key: "nonexistent") == nil)
         }
 
@@ -40,7 +40,7 @@ struct DefaultLiveMapTests {
                 data: ObjectData(boolean: true), // Value doesn't matter as it's tombstoned
             )
             let coreSDK = MockCoreSDK(channelState: .attaching)
-            let map = DefaultLiveMap(testsOnly_data: ["key": entry], delegate: nil, coreSDK: coreSDK)
+            let map = DefaultLiveMap(testsOnly_data: ["key": entry], objectID: "arbitrary", delegate: nil, coreSDK: coreSDK)
             #expect(try map.get(key: "key") == nil)
         }
 
@@ -49,7 +49,7 @@ struct DefaultLiveMapTests {
         func returnsBooleanValue() throws {
             let entry = TestFactories.mapEntry(data: ObjectData(boolean: true))
             let coreSDK = MockCoreSDK(channelState: .attaching)
-            let map = DefaultLiveMap(testsOnly_data: ["key": entry], delegate: nil, coreSDK: coreSDK)
+            let map = DefaultLiveMap(testsOnly_data: ["key": entry], objectID: "arbitrary", delegate: nil, coreSDK: coreSDK)
             let result = try map.get(key: "key")
             #expect(result?.boolValue == true)
         }
@@ -60,7 +60,7 @@ struct DefaultLiveMapTests {
             let bytes = Data([0x01, 0x02, 0x03])
             let entry = TestFactories.mapEntry(data: ObjectData(bytes: bytes))
             let coreSDK = MockCoreSDK(channelState: .attaching)
-            let map = DefaultLiveMap(testsOnly_data: ["key": entry], delegate: nil, coreSDK: coreSDK)
+            let map = DefaultLiveMap(testsOnly_data: ["key": entry], objectID: "arbitrary", delegate: nil, coreSDK: coreSDK)
             let result = try map.get(key: "key")
             #expect(result?.dataValue == bytes)
         }
@@ -70,7 +70,7 @@ struct DefaultLiveMapTests {
         func returnsNumberValue() throws {
             let entry = TestFactories.mapEntry(data: ObjectData(number: NSNumber(value: 123.456)))
             let coreSDK = MockCoreSDK(channelState: .attaching)
-            let map = DefaultLiveMap(testsOnly_data: ["key": entry], delegate: nil, coreSDK: coreSDK)
+            let map = DefaultLiveMap(testsOnly_data: ["key": entry], objectID: "arbitrary", delegate: nil, coreSDK: coreSDK)
             let result = try map.get(key: "key")
             #expect(result?.numberValue == 123.456)
         }
@@ -80,7 +80,7 @@ struct DefaultLiveMapTests {
         func returnsStringValue() throws {
             let entry = TestFactories.mapEntry(data: ObjectData(string: .string("test")))
             let coreSDK = MockCoreSDK(channelState: .attaching)
-            let map = DefaultLiveMap(testsOnly_data: ["key": entry], delegate: nil, coreSDK: coreSDK)
+            let map = DefaultLiveMap(testsOnly_data: ["key": entry], objectID: "arbitrary", delegate: nil, coreSDK: coreSDK)
             let result = try map.get(key: "key")
             #expect(result?.stringValue == "test")
         }
@@ -91,7 +91,7 @@ struct DefaultLiveMapTests {
             let entry = TestFactories.mapEntry(data: ObjectData(objectId: "missing"))
             let delegate = MockLiveMapObjectPoolDelegate()
             let coreSDK = MockCoreSDK(channelState: .attaching)
-            let map = DefaultLiveMap(testsOnly_data: ["key": entry], delegate: delegate, coreSDK: coreSDK)
+            let map = DefaultLiveMap(testsOnly_data: ["key": entry], objectID: "arbitrary", delegate: delegate, coreSDK: coreSDK)
             #expect(try map.get(key: "key") == nil)
         }
 
@@ -102,10 +102,10 @@ struct DefaultLiveMapTests {
             let entry = TestFactories.mapEntry(data: ObjectData(objectId: objectId))
             let delegate = MockLiveMapObjectPoolDelegate()
             let coreSDK = MockCoreSDK(channelState: .attaching)
-            let referencedMap = DefaultLiveMap.createZeroValued(delegate: delegate, coreSDK: coreSDK)
+            let referencedMap = DefaultLiveMap.createZeroValued(objectID: "arbitrary", delegate: delegate, coreSDK: coreSDK)
             delegate.objects[objectId] = .map(referencedMap)
 
-            let map = DefaultLiveMap(testsOnly_data: ["key": entry], delegate: delegate, coreSDK: coreSDK)
+            let map = DefaultLiveMap(testsOnly_data: ["key": entry], objectID: "arbitrary", delegate: delegate, coreSDK: coreSDK)
             let result = try map.get(key: "key")
             let returnedMap = result?.liveMapValue
             #expect(returnedMap as AnyObject === referencedMap as AnyObject)
@@ -118,9 +118,9 @@ struct DefaultLiveMapTests {
             let entry = TestFactories.mapEntry(data: ObjectData(objectId: objectId))
             let delegate = MockLiveMapObjectPoolDelegate()
             let coreSDK = MockCoreSDK(channelState: .attaching)
-            let referencedCounter = DefaultLiveCounter.createZeroValued(coreSDK: coreSDK)
+            let referencedCounter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: coreSDK)
             delegate.objects[objectId] = .counter(referencedCounter)
-            let map = DefaultLiveMap(testsOnly_data: ["key": entry], delegate: delegate, coreSDK: coreSDK)
+            let map = DefaultLiveMap(testsOnly_data: ["key": entry], objectID: "arbitrary", delegate: delegate, coreSDK: coreSDK)
             let result = try map.get(key: "key")
             let returnedCounter = result?.liveCounterValue
             #expect(returnedCounter as AnyObject === referencedCounter as AnyObject)
@@ -133,7 +133,7 @@ struct DefaultLiveMapTests {
             let delegate = MockLiveMapObjectPoolDelegate()
             let coreSDK = MockCoreSDK(channelState: .attaching)
 
-            let map = DefaultLiveMap(testsOnly_data: ["key": entry], delegate: delegate, coreSDK: coreSDK)
+            let map = DefaultLiveMap(testsOnly_data: ["key": entry], objectID: "arbitrary", delegate: delegate, coreSDK: coreSDK)
             #expect(try map.get(key: "key") == nil)
         }
     }
@@ -145,7 +145,7 @@ struct DefaultLiveMapTests {
         func replacesSiteTimeserials() {
             let delegate = MockLiveMapObjectPoolDelegate()
             let coreSDK = MockCoreSDK(channelState: .attaching)
-            let map = DefaultLiveMap.createZeroValued(delegate: delegate, coreSDK: coreSDK)
+            let map = DefaultLiveMap.createZeroValued(objectID: "arbitrary", delegate: delegate, coreSDK: coreSDK)
             let state = TestFactories.objectState(
                 objectId: "arbitrary-id",
                 siteTimeserials: ["site1": "ts1", "site2": "ts2"],
@@ -158,13 +158,29 @@ struct DefaultLiveMapTests {
         // @spec RTLM6b
         @Test
         func setsCreateOperationIsMergedToFalseWhenCreateOpAbsent() {
+            // Given:
             let delegate = MockLiveMapObjectPoolDelegate()
             let coreSDK = MockCoreSDK(channelState: .attaching)
-            let map = DefaultLiveMap.createZeroValued(delegate: delegate, coreSDK: coreSDK)
-            let state = TestFactories.objectState(objectId: "arbitrary-id", createOp: nil)
             var pool = ObjectsPool(rootDelegate: delegate, rootCoreSDK: coreSDK)
+            let map = {
+                let map = DefaultLiveMap.createZeroValued(objectID: "arbitrary", delegate: delegate, coreSDK: coreSDK)
+
+                // Test setup: Manipulate map so that its createOperationIsMerged gets set to true (we need to do this since we want to later assert that it gets set to false, but the default is false).
+                let state = TestFactories.objectState(
+                    createOp: TestFactories.mapCreateOperation(objectId: "arbitrary-id"),
+                )
+                map.replaceData(using: state, objectsPool: &pool)
+                #expect(map.testsOnly_createOperationIsMerged)
+
+                return map
+            }()
+
+            // When:
+            let state = TestFactories.objectState(objectId: "arbitrary-id", createOp: nil)
             map.replaceData(using: state, objectsPool: &pool)
-            #expect(map.testsOnly_createOperationIsMerged == false)
+
+            // Then:
+            #expect(!map.testsOnly_createOperationIsMerged)
         }
 
         // @specOneOf(1/2) RTLM6c
@@ -172,7 +188,7 @@ struct DefaultLiveMapTests {
         func setsDataToMapEntries() throws {
             let delegate = MockLiveMapObjectPoolDelegate()
             let coreSDK = MockCoreSDK(channelState: .attaching)
-            let map = DefaultLiveMap.createZeroValued(delegate: delegate, coreSDK: coreSDK)
+            let map = DefaultLiveMap.createZeroValued(objectID: "arbitrary", delegate: delegate, coreSDK: coreSDK)
             let (key, entry) = TestFactories.stringMapEntry(key: "key1", value: "test")
             let state = TestFactories.mapObjectState(
                 objectId: "arbitrary-id",
@@ -192,7 +208,7 @@ struct DefaultLiveMapTests {
         func appliesMapSetOperationFromCreateOp() throws {
             let delegate = MockLiveMapObjectPoolDelegate()
             let coreSDK = MockCoreSDK(channelState: .attaching)
-            let map = DefaultLiveMap.createZeroValued(delegate: delegate, coreSDK: coreSDK)
+            let map = DefaultLiveMap.createZeroValued(objectID: "arbitrary", delegate: delegate, coreSDK: coreSDK)
             let state = TestFactories.objectState(
                 objectId: "arbitrary-id",
                 createOp: TestFactories.mapCreateOperation(
@@ -223,6 +239,7 @@ struct DefaultLiveMapTests {
             let coreSDK = MockCoreSDK(channelState: .attaching)
             let map = DefaultLiveMap(
                 testsOnly_data: ["key1": TestFactories.stringMapEntry().entry],
+                objectID: "arbitrary",
                 delegate: delegate,
                 coreSDK: coreSDK,
             )
@@ -252,14 +269,14 @@ struct DefaultLiveMapTests {
         func setsCreateOperationIsMergedToTrueWhenCreateOpPresent() {
             let delegate = MockLiveMapObjectPoolDelegate()
             let coreSDK = MockCoreSDK(channelState: .attaching)
-            let map = DefaultLiveMap.createZeroValued(delegate: delegate, coreSDK: coreSDK)
+            let map = DefaultLiveMap.createZeroValued(objectID: "arbitrary", delegate: delegate, coreSDK: coreSDK)
             let state = TestFactories.objectState(
                 objectId: "arbitrary-id",
                 createOp: TestFactories.mapCreateOperation(objectId: "arbitrary-id"),
             )
             var pool = ObjectsPool(rootDelegate: delegate, rootCoreSDK: coreSDK)
             map.replaceData(using: state, objectsPool: &pool)
-            #expect(map.testsOnly_createOperationIsMerged == true)
+            #expect(map.testsOnly_createOperationIsMerged)
         }
     }
 
@@ -273,7 +290,7 @@ struct DefaultLiveMapTests {
         // @spec RTLM13b
         @Test(arguments: [.detached, .failed] as [ARTRealtimeChannelState])
         func allPropertiesThrowIfChannelIsDetachedOrFailed(channelState: ARTRealtimeChannelState) async throws {
-            let map = DefaultLiveMap.createZeroValued(delegate: MockLiveMapObjectPoolDelegate(), coreSDK: MockCoreSDK(channelState: channelState))
+            let map = DefaultLiveMap.createZeroValued(objectID: "arbitrary", delegate: MockLiveMapObjectPoolDelegate(), coreSDK: MockCoreSDK(channelState: channelState))
 
             // Define actions to test
             let actions: [(String, () throws -> Any)] = [
@@ -315,6 +332,7 @@ struct DefaultLiveMapTests {
                     "tombstoned": TestFactories.mapEntry(tombstone: true, data: ObjectData(string: .string("tombstoned"))),
                     "tombstoned2": TestFactories.mapEntry(tombstone: true, data: ObjectData(string: .string("tombstoned2"))),
                 ],
+                objectID: "arbitrary",
                 delegate: nil,
                 coreSDK: coreSDK,
             )
@@ -355,6 +373,7 @@ struct DefaultLiveMapTests {
                     "key2": TestFactories.mapEntry(data: ObjectData(string: .string("value2"))),
                     "key3": TestFactories.mapEntry(data: ObjectData(string: .string("value3"))),
                 ],
+                objectID: "arbitrary",
                 delegate: nil,
                 coreSDK: coreSDK,
             )
@@ -386,8 +405,8 @@ struct DefaultLiveMapTests {
             let coreSDK = MockCoreSDK(channelState: .attaching)
 
             // Create referenced objects for testing
-            let referencedMap = DefaultLiveMap.createZeroValued(delegate: delegate, coreSDK: coreSDK)
-            let referencedCounter = DefaultLiveCounter.createZeroValued(coreSDK: coreSDK)
+            let referencedMap = DefaultLiveMap.createZeroValued(objectID: "arbitrary", delegate: delegate, coreSDK: coreSDK)
+            let referencedCounter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: coreSDK)
             delegate.objects["map:ref@123"] = .map(referencedMap)
             delegate.objects["counter:ref@456"] = .counter(referencedCounter)
 
@@ -400,6 +419,7 @@ struct DefaultLiveMapTests {
                     "mapRef": TestFactories.mapEntry(data: ObjectData(objectId: "map:ref@123")), // RTLM5d2f2
                     "counterRef": TestFactories.mapEntry(data: ObjectData(objectId: "counter:ref@456")), // RTLM5d2f2
                 ],
+                objectID: "arbitrary",
                 delegate: delegate,
                 coreSDK: coreSDK,
             )
@@ -443,6 +463,7 @@ struct DefaultLiveMapTests {
                 let coreSDK = MockCoreSDK(channelState: .attaching)
                 let map = DefaultLiveMap(
                     testsOnly_data: ["key1": TestFactories.mapEntry(timeserial: "ts2", data: ObjectData(string: .string("existing")))],
+                    objectID: "arbitrary",
                     delegate: delegate,
                     coreSDK: coreSDK,
                 )
@@ -477,6 +498,7 @@ struct DefaultLiveMapTests {
                 let coreSDK = MockCoreSDK(channelState: .attaching)
                 let map = DefaultLiveMap(
                     testsOnly_data: ["key1": TestFactories.mapEntry(tombstone: true, timeserial: "ts1", data: ObjectData(string: .string("existing")))],
+                    objectID: "arbitrary",
                     delegate: delegate,
                     coreSDK: coreSDK,
                 )
@@ -541,7 +563,7 @@ struct DefaultLiveMapTests {
             func createsNewEntryWhenNoExistingEntry(operationData: ObjectData, expectedCreatedObjectID: String?) throws {
                 let delegate = MockLiveMapObjectPoolDelegate()
                 let coreSDK = MockCoreSDK(channelState: .attaching)
-                let map = DefaultLiveMap.createZeroValued(delegate: delegate, coreSDK: coreSDK)
+                let map = DefaultLiveMap.createZeroValued(objectID: "arbitrary", delegate: delegate, coreSDK: coreSDK)
                 var pool = ObjectsPool(rootDelegate: delegate, rootCoreSDK: coreSDK)
 
                 map.testsOnly_applyMapSetOperation(
@@ -587,12 +609,13 @@ struct DefaultLiveMapTests {
         func doesNotReplaceExistingObjectWhenReferencedByMapSet() throws {
             let delegate = MockLiveMapObjectPoolDelegate()
             let coreSDK = MockCoreSDK(channelState: .attaching)
-            let map = DefaultLiveMap.createZeroValued(delegate: delegate, coreSDK: coreSDK)
+            let map = DefaultLiveMap.createZeroValued(objectID: "arbitrary", delegate: delegate, coreSDK: coreSDK)
 
             // Create an existing object in the pool with some data
             let existingObjectId = "map:existing@123"
             let existingObject = DefaultLiveMap(
                 testsOnly_data: [:],
+                objectID: "arbitrary",
                 delegate: delegate,
                 coreSDK: coreSDK,
             )
@@ -634,6 +657,7 @@ struct DefaultLiveMapTests {
                 let coreSDK = MockCoreSDK(channelState: .attaching)
                 let map = DefaultLiveMap(
                     testsOnly_data: ["key1": TestFactories.mapEntry(timeserial: "ts2", data: ObjectData(string: .string("existing")))],
+                    objectID: "arbitrary",
                     delegate: delegate,
                     coreSDK: coreSDK,
                 )
@@ -654,6 +678,7 @@ struct DefaultLiveMapTests {
                 let coreSDK = MockCoreSDK(channelState: .attaching)
                 let map = DefaultLiveMap(
                     testsOnly_data: ["key1": TestFactories.mapEntry(tombstone: false, timeserial: "ts1", data: ObjectData(string: .string("existing")))],
+                    objectID: "arbitrary",
                     delegate: delegate,
                     coreSDK: coreSDK,
                 )
@@ -688,7 +713,7 @@ struct DefaultLiveMapTests {
             func createsNewEntryWhenNoExistingEntry() throws {
                 let delegate = MockLiveMapObjectPoolDelegate()
                 let coreSDK = MockCoreSDK(channelState: .attaching)
-                let map = DefaultLiveMap.createZeroValued(delegate: delegate, coreSDK: coreSDK)
+                let map = DefaultLiveMap.createZeroValued(objectID: "arbitrary", delegate: delegate, coreSDK: coreSDK)
 
                 map.testsOnly_applyMapRemoveOperation(key: "newKey", operationTimeserial: "ts1")
 
@@ -708,7 +733,7 @@ struct DefaultLiveMapTests {
             func setsNewEntryTombstoneToTrue() throws {
                 let delegate = MockLiveMapObjectPoolDelegate()
                 let coreSDK = MockCoreSDK(channelState: .attaching)
-                let map = DefaultLiveMap.createZeroValued(delegate: delegate, coreSDK: coreSDK)
+                let map = DefaultLiveMap.createZeroValued(objectID: "arbitrary", delegate: delegate, coreSDK: coreSDK)
 
                 map.testsOnly_applyMapRemoveOperation(key: "newKey", operationTimeserial: "ts1")
 
@@ -771,6 +796,7 @@ struct DefaultLiveMapTests {
             let coreSDK = MockCoreSDK(channelState: .attaching)
             let map = DefaultLiveMap(
                 testsOnly_data: ["key1": TestFactories.mapEntry(timeserial: entrySerial, data: ObjectData(string: .string("existing")))],
+                objectID: "arbitrary",
                 delegate: delegate,
                 coreSDK: coreSDK,
             )

--- a/Tests/AblyLiveObjectsTests/Helpers/TestFactories.swift
+++ b/Tests/AblyLiveObjectsTests/Helpers/TestFactories.swift
@@ -386,6 +386,11 @@ struct TestFactories {
         )
     }
 
+    /// Creates a WireObjectsCounterOp
+    static func counterOp(amount: Int = 10) -> WireObjectsCounterOp {
+        WireObjectsCounterOp(amount: NSNumber(value: amount))
+    }
+
     // MARK: - ObjectsMapEntry Factory
 
     /// Creates an ObjectsMapEntry with sensible defaults
@@ -514,6 +519,100 @@ struct TestFactories {
     /// Creates a WireObjectsCounter with sensible defaults
     static func wireObjectsCounter(count: Int? = 42) -> WireObjectsCounter {
         WireObjectsCounter(count: count.map { NSNumber(value: $0) })
+    }
+
+    // MARK: - Operation Message Factories
+
+    /// Creates an InboundObjectMessage with a MAP_SET operation
+    static func mapSetOperationMessage(
+        objectId: String = "map:test@123",
+        key: String = "testKey",
+        value: String = "testValue",
+        serial: String = "ts1",
+        siteCode: String = "site1",
+    ) -> InboundObjectMessage {
+        inboundObjectMessage(
+            operation: objectOperation(
+                action: .known(.mapSet),
+                objectId: objectId,
+                mapOp: ObjectsMapOp(
+                    key: key,
+                    data: ObjectData(string: .string(value)),
+                ),
+            ),
+            serial: serial,
+            siteCode: siteCode,
+        )
+    }
+
+    /// Creates an InboundObjectMessage with a MAP_REMOVE operation
+    static func mapRemoveOperationMessage(
+        objectId: String = "map:test@123",
+        key: String = "testKey",
+        serial: String = "ts1",
+        siteCode: String = "site1",
+    ) -> InboundObjectMessage {
+        inboundObjectMessage(
+            operation: objectOperation(
+                action: .known(.mapRemove),
+                objectId: objectId,
+                mapOp: ObjectsMapOp(key: key),
+            ),
+            serial: serial,
+            siteCode: siteCode,
+        )
+    }
+
+    /// Creates an InboundObjectMessage with a MAP_CREATE operation
+    static func mapCreateOperationMessage(
+        objectId: String = "map:test@123",
+        entries: [String: ObjectsMapEntry]? = nil,
+        serial: String = "ts1",
+        siteCode: String = "site1",
+    ) -> InboundObjectMessage {
+        inboundObjectMessage(
+            operation: mapCreateOperation(
+                objectId: objectId,
+                entries: entries,
+            ),
+            serial: serial,
+            siteCode: siteCode,
+        )
+    }
+
+    /// Creates an InboundObjectMessage with a COUNTER_CREATE operation
+    static func counterCreateOperationMessage(
+        objectId: String = "counter:test@123",
+        count: Int? = 42,
+        serial: String = "ts1",
+        siteCode: String = "site1",
+    ) -> InboundObjectMessage {
+        inboundObjectMessage(
+            operation: counterCreateOperation(
+                objectId: objectId,
+                count: count,
+            ),
+            serial: serial,
+            siteCode: siteCode,
+        )
+    }
+
+    /// Creates an InboundObjectMessage with a COUNTER_INC operation
+    static func counterIncOperationMessage(
+        objectId: String = "counter:test@123",
+        amount: Int = 10,
+        serial: String = "ts1",
+        siteCode: String = "site1",
+    ) -> InboundObjectMessage {
+        inboundObjectMessage(
+            operation: objectOperation(
+                action: .known(.counterInc),
+                objectId: objectId,
+                counterOp: counterOp(amount: amount),
+            ),
+            serial: serial,
+            siteCode: siteCode,
+        )
     }
 
     // MARK: - Common Test Scenarios

--- a/Tests/AblyLiveObjectsTests/LiveObjectMutableStateTests.swift
+++ b/Tests/AblyLiveObjectsTests/LiveObjectMutableStateTests.swift
@@ -1,0 +1,116 @@
+import Ably
+@testable import AblyLiveObjects
+import AblyPlugin
+import Testing
+
+/// Tests for `LiveObjectMutableState`.
+struct LiveObjectMutableStateTests {
+    /// Tests for `LiveObjectMutableState.canApplyOperation`, covering RTLO4 specification points.
+    struct CanApplyOperationTests {
+        /// Test case data for canApplyOperation tests
+        struct TestCase {
+            let description: String
+            let objectMessageSerial: String?
+            let objectMessageSiteCode: String?
+            let siteTimeserials: [String: String]
+            let expectedResult: LiveObjectMutableState.ApplicableOperation?
+        }
+
+        // @spec RTLO4a3
+        // @spec RTLO4a4
+        // @spec RTLO4a5
+        // @spec RTLO4a6
+        @Test(arguments: [
+            // RTLO4a3: Both ObjectMessage.serial and ObjectMessage.siteCode must be non-empty strings
+            TestCase(
+                description: "serial is nil, siteCode is valid - should return nil",
+                objectMessageSerial: nil,
+                objectMessageSiteCode: "site1",
+                siteTimeserials: [:],
+                expectedResult: nil,
+            ),
+            TestCase(
+                description: "serial is empty string, siteCode is valid - should return nil",
+                objectMessageSerial: "",
+                objectMessageSiteCode: "site1",
+                siteTimeserials: [:],
+                expectedResult: nil,
+            ),
+            TestCase(
+                description: "serial is valid, siteCode is nil - should return nil",
+                objectMessageSerial: "serial1",
+                objectMessageSiteCode: nil,
+                siteTimeserials: [:],
+                expectedResult: nil,
+            ),
+            TestCase(
+                description: "serial is valid, siteCode is empty string - should return nil",
+                objectMessageSerial: "serial1",
+                objectMessageSiteCode: "",
+                siteTimeserials: [:],
+                expectedResult: nil,
+            ),
+            TestCase(
+                description: "both serial and siteCode are invalid - should return nil",
+                objectMessageSerial: nil,
+                objectMessageSiteCode: "",
+                siteTimeserials: [:],
+                expectedResult: nil,
+            ),
+
+            // RTLO4a5: If the siteSerial for this LiveObject is null or an empty string, return ApplicableOperation
+            TestCase(
+                description: "siteSerial is nil (siteCode doesn't exist) - should return ApplicableOperation",
+                objectMessageSerial: "serial2",
+                objectMessageSiteCode: "site1",
+                siteTimeserials: ["site2": "serial1"], // i.e. only has an entry for a different siteCode
+                expectedResult: LiveObjectMutableState.ApplicableOperation(objectMessageSerial: "serial2", objectMessageSiteCode: "site1"),
+            ),
+            TestCase(
+                description: "siteSerial is empty string - should return ApplicableOperation",
+                objectMessageSerial: "serial2",
+                objectMessageSiteCode: "site1",
+                siteTimeserials: ["site1": "", "site2": "serial1"],
+                expectedResult: LiveObjectMutableState.ApplicableOperation(objectMessageSerial: "serial2", objectMessageSiteCode: "site1"),
+            ),
+
+            // RTLO4a6: If the siteSerial for this LiveObject is not an empty string, return ApplicableOperation if ObjectMessage.serial is greater than siteSerial when compared lexicographically
+            TestCase(
+                description: "serial is greater than siteSerial lexicographically - should return ApplicableOperation",
+                objectMessageSerial: "serial2",
+                objectMessageSiteCode: "site1",
+                siteTimeserials: ["site1": "serial1"],
+                expectedResult: LiveObjectMutableState.ApplicableOperation(objectMessageSerial: "serial2", objectMessageSiteCode: "site1"),
+            ),
+            TestCase(
+                description: "serial is less than siteSerial lexicographically - should return nil",
+                objectMessageSerial: "serial1",
+                objectMessageSiteCode: "site1",
+                siteTimeserials: ["site1": "serial2"],
+                expectedResult: nil,
+            ),
+            TestCase(
+                description: "serial equals siteSerial - should return nil",
+                objectMessageSerial: "serial1",
+                objectMessageSiteCode: "site1",
+                siteTimeserials: ["site1": "serial1"],
+                expectedResult: nil,
+            ),
+        ])
+        func canApplyOperation(testCase: TestCase) {
+            let state = LiveObjectMutableState(
+                objectID: "test:object@123",
+                siteTimeserials: testCase.siteTimeserials,
+            )
+            let logger = TestLogger()
+
+            let result = state.canApplyOperation(
+                objectMessageSerial: testCase.objectMessageSerial,
+                objectMessageSiteCode: testCase.objectMessageSiteCode,
+                logger: logger,
+            )
+
+            #expect(result == testCase.expectedResult, "Expected \(String(describing: testCase.expectedResult)) for case: \(testCase.description)")
+        }
+    }
+}

--- a/Tests/AblyLiveObjectsTests/ObjectsPoolTests.swift
+++ b/Tests/AblyLiveObjectsTests/ObjectsPoolTests.swift
@@ -8,12 +8,13 @@ struct ObjectsPoolTests {
         // @spec RTO6a
         @Test
         func returnsExistingObject() throws {
+            let logger = TestLogger()
             let delegate = MockLiveMapObjectPoolDelegate()
             let coreSDK = MockCoreSDK(channelState: .attaching)
-            let existingMap = DefaultLiveMap.createZeroValued(objectID: "arbitrary", delegate: delegate, coreSDK: coreSDK)
-            var pool = ObjectsPool(rootDelegate: delegate, rootCoreSDK: coreSDK, testsOnly_otherEntries: ["map:123@456": .map(existingMap)])
+            let existingMap = DefaultLiveMap.createZeroValued(objectID: "arbitrary", delegate: delegate, coreSDK: coreSDK, logger: logger)
+            var pool = ObjectsPool(rootDelegate: delegate, rootCoreSDK: coreSDK, logger: logger, testsOnly_otherEntries: ["map:123@456": .map(existingMap)])
 
-            let result = pool.createZeroValueObject(forObjectID: "map:123@456", mapDelegate: delegate, coreSDK: coreSDK)
+            let result = pool.createZeroValueObject(forObjectID: "map:123@456", mapDelegate: delegate, coreSDK: coreSDK, logger: logger)
             let map = try #require(result?.mapValue)
             #expect(map as AnyObject === existingMap as AnyObject)
         }
@@ -21,11 +22,12 @@ struct ObjectsPoolTests {
         // @spec RTO6b2
         @Test
         func createsZeroValueMap() throws {
+            let logger = TestLogger()
             let delegate = MockLiveMapObjectPoolDelegate()
             let coreSDK = MockCoreSDK(channelState: .attaching)
-            var pool = ObjectsPool(rootDelegate: delegate, rootCoreSDK: coreSDK)
+            var pool = ObjectsPool(rootDelegate: delegate, rootCoreSDK: coreSDK, logger: logger)
 
-            let result = pool.createZeroValueObject(forObjectID: "map:123@456", mapDelegate: delegate, coreSDK: coreSDK)
+            let result = pool.createZeroValueObject(forObjectID: "map:123@456", mapDelegate: delegate, coreSDK: coreSDK, logger: logger)
             let map = try #require(result?.mapValue)
 
             // Verify it was added to the pool
@@ -40,11 +42,12 @@ struct ObjectsPoolTests {
         // @spec RTO6b3
         @Test
         func createsZeroValueCounter() throws {
+            let logger = TestLogger()
             let delegate = MockLiveMapObjectPoolDelegate()
             let coreSDK = MockCoreSDK(channelState: .attaching)
-            var pool = ObjectsPool(rootDelegate: delegate, rootCoreSDK: coreSDK)
+            var pool = ObjectsPool(rootDelegate: delegate, rootCoreSDK: coreSDK, logger: logger)
 
-            let result = pool.createZeroValueObject(forObjectID: "counter:123@456", mapDelegate: delegate, coreSDK: coreSDK)
+            let result = pool.createZeroValueObject(forObjectID: "counter:123@456", mapDelegate: delegate, coreSDK: coreSDK, logger: logger)
             let counter = try #require(result?.counterValue)
             #expect(try counter.value == 0)
 
@@ -57,22 +60,24 @@ struct ObjectsPoolTests {
         // Sense check to see how it behaves when given an object ID not in the format of RTO6b1 (spec isn't prescriptive here)
         @Test
         func returnsNilForInvalidObjectId() throws {
+            let logger = TestLogger()
             let delegate = MockLiveMapObjectPoolDelegate()
             let coreSDK = MockCoreSDK(channelState: .attaching)
-            var pool = ObjectsPool(rootDelegate: delegate, rootCoreSDK: coreSDK)
+            var pool = ObjectsPool(rootDelegate: delegate, rootCoreSDK: coreSDK, logger: logger)
 
-            let result = pool.createZeroValueObject(forObjectID: "invalid", mapDelegate: delegate, coreSDK: coreSDK)
+            let result = pool.createZeroValueObject(forObjectID: "invalid", mapDelegate: delegate, coreSDK: coreSDK, logger: logger)
             #expect(result == nil)
         }
 
         // Sense check to see how it behaves when given an object ID not covered by RTO6b2 or RTO6b3
         @Test
         func returnsNilForUnknownType() throws {
+            let logger = TestLogger()
             let delegate = MockLiveMapObjectPoolDelegate()
             let coreSDK = MockCoreSDK(channelState: .attaching)
-            var pool = ObjectsPool(rootDelegate: delegate, rootCoreSDK: coreSDK)
+            var pool = ObjectsPool(rootDelegate: delegate, rootCoreSDK: coreSDK, logger: logger)
 
-            let result = pool.createZeroValueObject(forObjectID: "unknown:123@456", mapDelegate: delegate, coreSDK: coreSDK)
+            let result = pool.createZeroValueObject(forObjectID: "unknown:123@456", mapDelegate: delegate, coreSDK: coreSDK, logger: logger)
             #expect(result == nil)
             #expect(pool.entries["unknown:123@456"] == nil)
         }
@@ -85,11 +90,11 @@ struct ObjectsPoolTests {
         // @specOneOf(1/2) RTO5c1a1 - Override the internal data for existing map objects
         @Test
         func updatesExistingMapObject() throws {
+            let logger = TestLogger()
             let delegate = MockLiveMapObjectPoolDelegate()
             let coreSDK = MockCoreSDK(channelState: .attaching)
-            let existingMap = DefaultLiveMap.createZeroValued(objectID: "arbitrary", delegate: delegate, coreSDK: coreSDK)
-            var pool = ObjectsPool(rootDelegate: delegate, rootCoreSDK: coreSDK, testsOnly_otherEntries: ["map:hash@123": .map(existingMap)])
-            let logger = TestLogger()
+            let existingMap = DefaultLiveMap.createZeroValued(objectID: "arbitrary", delegate: delegate, coreSDK: coreSDK, logger: logger)
+            var pool = ObjectsPool(rootDelegate: delegate, rootCoreSDK: coreSDK, logger: logger, testsOnly_otherEntries: ["map:hash@123": .map(existingMap)])
 
             let (key, entry) = TestFactories.stringMapEntry(key: "key1", value: "updated_value")
             let objectState = TestFactories.mapObjectState(
@@ -112,11 +117,11 @@ struct ObjectsPoolTests {
         // @specOneOf(2/2) RTO5c1a1 - Override the internal data for existing counter objects
         @Test
         func updatesExistingCounterObject() throws {
+            let logger = TestLogger()
             let delegate = MockLiveMapObjectPoolDelegate()
             let coreSDK = MockCoreSDK(channelState: .attaching)
-            let existingCounter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: coreSDK)
-            var pool = ObjectsPool(rootDelegate: delegate, rootCoreSDK: coreSDK, testsOnly_otherEntries: ["counter:hash@123": .counter(existingCounter)])
-            let logger = TestLogger()
+            let existingCounter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: coreSDK, logger: logger)
+            var pool = ObjectsPool(rootDelegate: delegate, rootCoreSDK: coreSDK, logger: logger, testsOnly_otherEntries: ["counter:hash@123": .counter(existingCounter)])
 
             let objectState = TestFactories.counterObjectState(
                 objectId: "counter:hash@123",
@@ -138,10 +143,10 @@ struct ObjectsPoolTests {
         // @spec RTO5c1b1a
         @Test
         func createsNewCounterObject() throws {
+            let logger = TestLogger()
             let delegate = MockLiveMapObjectPoolDelegate()
             let coreSDK = MockCoreSDK(channelState: .attaching)
-            var pool = ObjectsPool(rootDelegate: delegate, rootCoreSDK: coreSDK)
-            let logger = TestLogger()
+            var pool = ObjectsPool(rootDelegate: delegate, rootCoreSDK: coreSDK, logger: logger)
 
             let objectState = TestFactories.counterObjectState(
                 objectId: "counter:hash@456",
@@ -164,11 +169,11 @@ struct ObjectsPoolTests {
         // @spec RTO5c1b1b
         @Test
         func createsNewMapObject() throws {
+            let logger = TestLogger()
             let delegate = MockLiveMapObjectPoolDelegate()
             let coreSDK = MockCoreSDK(channelState: .attaching)
 
-            var pool = ObjectsPool(rootDelegate: delegate, rootCoreSDK: coreSDK)
-            let logger = TestLogger()
+            var pool = ObjectsPool(rootDelegate: delegate, rootCoreSDK: coreSDK, logger: logger)
 
             let (key, entry) = TestFactories.stringMapEntry(key: "key2", value: "new_value")
             let objectState = TestFactories.mapObjectState(
@@ -195,10 +200,10 @@ struct ObjectsPoolTests {
         // @spec RTO5c1b1c
         @Test
         func ignoresNonMapOrCounterObject() throws {
+            let logger = TestLogger()
             let delegate = MockLiveMapObjectPoolDelegate()
             let coreSDK = MockCoreSDK(channelState: .attaching)
-            var pool = ObjectsPool(rootDelegate: delegate, rootCoreSDK: coreSDK)
-            let logger = TestLogger()
+            var pool = ObjectsPool(rootDelegate: delegate, rootCoreSDK: coreSDK, logger: logger)
 
             let validObjectState = TestFactories.counterObjectState(
                 objectId: "counter:hash@456",
@@ -219,18 +224,18 @@ struct ObjectsPoolTests {
         // @spec(RTO5c2) Remove objects not received during sync
         @Test
         func removesObjectsNotInSync() throws {
+            let logger = TestLogger()
             let delegate = MockLiveMapObjectPoolDelegate()
             let coreSDK = MockCoreSDK(channelState: .attaching)
-            let existingMap1 = DefaultLiveMap.createZeroValued(objectID: "arbitrary", delegate: delegate, coreSDK: coreSDK)
-            let existingMap2 = DefaultLiveMap.createZeroValued(objectID: "arbitrary", delegate: delegate, coreSDK: coreSDK)
-            let existingCounter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: coreSDK)
+            let existingMap1 = DefaultLiveMap.createZeroValued(objectID: "arbitrary", delegate: delegate, coreSDK: coreSDK, logger: logger)
+            let existingMap2 = DefaultLiveMap.createZeroValued(objectID: "arbitrary", delegate: delegate, coreSDK: coreSDK, logger: logger)
+            let existingCounter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: coreSDK, logger: logger)
 
-            var pool = ObjectsPool(rootDelegate: delegate, rootCoreSDK: coreSDK, testsOnly_otherEntries: [
+            var pool = ObjectsPool(rootDelegate: delegate, rootCoreSDK: coreSDK, logger: logger, testsOnly_otherEntries: [
                 "map:hash@1": .map(existingMap1),
                 "map:hash@2": .map(existingMap2),
                 "counter:hash@1": .counter(existingCounter),
             ])
-            let logger = TestLogger()
 
             // Only sync one of the existing objects
             let objectState = TestFactories.mapObjectState(objectId: "map:hash@1")
@@ -248,11 +253,11 @@ struct ObjectsPoolTests {
         // @spec(RTO5c2a) Root object must not be removed
         @Test
         func doesNotRemoveRootObject() throws {
+            let logger = TestLogger()
             let delegate = MockLiveMapObjectPoolDelegate()
             let coreSDK = MockCoreSDK(channelState: .attaching)
-            let existingMap = DefaultLiveMap.createZeroValued(objectID: "arbitrary", delegate: delegate, coreSDK: coreSDK)
-            var pool = ObjectsPool(rootDelegate: delegate, rootCoreSDK: coreSDK, testsOnly_otherEntries: ["map:hash@1": .map(existingMap)])
-            let logger = TestLogger()
+            let existingMap = DefaultLiveMap.createZeroValued(objectID: "arbitrary", delegate: delegate, coreSDK: coreSDK, logger: logger)
+            var pool = ObjectsPool(rootDelegate: delegate, rootCoreSDK: coreSDK, logger: logger, testsOnly_otherEntries: ["map:hash@1": .map(existingMap)])
 
             // Sync with empty list (no objects)
             pool.applySyncObjectsPool([], mapDelegate: delegate, coreSDK: coreSDK, logger: logger)
@@ -266,19 +271,19 @@ struct ObjectsPoolTests {
         // @spec(RTO5c1, RTO5c2) Complete sync scenario with mixed operations
         @Test
         func handlesComplexSyncScenario() throws {
+            let logger = TestLogger()
             let delegate = MockLiveMapObjectPoolDelegate()
             let coreSDK = MockCoreSDK(channelState: .attaching)
 
-            let existingMap = DefaultLiveMap.createZeroValued(objectID: "arbitrary", delegate: delegate, coreSDK: coreSDK)
-            let existingCounter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: coreSDK)
-            let toBeRemovedMap = DefaultLiveMap.createZeroValued(objectID: "arbitrary", delegate: delegate, coreSDK: coreSDK)
+            let existingMap = DefaultLiveMap.createZeroValued(objectID: "arbitrary", delegate: delegate, coreSDK: coreSDK, logger: logger)
+            let existingCounter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: coreSDK, logger: logger)
+            let toBeRemovedMap = DefaultLiveMap.createZeroValued(objectID: "arbitrary", delegate: delegate, coreSDK: coreSDK, logger: logger)
 
-            var pool = ObjectsPool(rootDelegate: delegate, rootCoreSDK: coreSDK, testsOnly_otherEntries: [
+            var pool = ObjectsPool(rootDelegate: delegate, rootCoreSDK: coreSDK, logger: logger, testsOnly_otherEntries: [
                 "map:existing@1": .map(existingMap),
                 "counter:existing@1": .counter(existingCounter),
                 "map:toremove@1": .map(toBeRemovedMap),
             ])
-            let logger = TestLogger()
 
             let syncObjects = [
                 // Update existing map

--- a/Tests/AblyLiveObjectsTests/ObjectsPoolTests.swift
+++ b/Tests/AblyLiveObjectsTests/ObjectsPoolTests.swift
@@ -10,7 +10,7 @@ struct ObjectsPoolTests {
         func returnsExistingObject() throws {
             let delegate = MockLiveMapObjectPoolDelegate()
             let coreSDK = MockCoreSDK(channelState: .attaching)
-            let existingMap = DefaultLiveMap.createZeroValued(delegate: delegate, coreSDK: coreSDK)
+            let existingMap = DefaultLiveMap.createZeroValued(objectID: "arbitrary", delegate: delegate, coreSDK: coreSDK)
             var pool = ObjectsPool(rootDelegate: delegate, rootCoreSDK: coreSDK, testsOnly_otherEntries: ["map:123@456": .map(existingMap)])
 
             let result = pool.createZeroValueObject(forObjectID: "map:123@456", mapDelegate: delegate, coreSDK: coreSDK)
@@ -87,7 +87,7 @@ struct ObjectsPoolTests {
         func updatesExistingMapObject() throws {
             let delegate = MockLiveMapObjectPoolDelegate()
             let coreSDK = MockCoreSDK(channelState: .attaching)
-            let existingMap = DefaultLiveMap.createZeroValued(delegate: delegate, coreSDK: coreSDK)
+            let existingMap = DefaultLiveMap.createZeroValued(objectID: "arbitrary", delegate: delegate, coreSDK: coreSDK)
             var pool = ObjectsPool(rootDelegate: delegate, rootCoreSDK: coreSDK, testsOnly_otherEntries: ["map:hash@123": .map(existingMap)])
             let logger = TestLogger()
 
@@ -114,7 +114,7 @@ struct ObjectsPoolTests {
         func updatesExistingCounterObject() throws {
             let delegate = MockLiveMapObjectPoolDelegate()
             let coreSDK = MockCoreSDK(channelState: .attaching)
-            let existingCounter = DefaultLiveCounter.createZeroValued(coreSDK: coreSDK)
+            let existingCounter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: coreSDK)
             var pool = ObjectsPool(rootDelegate: delegate, rootCoreSDK: coreSDK, testsOnly_otherEntries: ["counter:hash@123": .counter(existingCounter)])
             let logger = TestLogger()
 
@@ -221,9 +221,9 @@ struct ObjectsPoolTests {
         func removesObjectsNotInSync() throws {
             let delegate = MockLiveMapObjectPoolDelegate()
             let coreSDK = MockCoreSDK(channelState: .attaching)
-            let existingMap1 = DefaultLiveMap.createZeroValued(delegate: delegate, coreSDK: coreSDK)
-            let existingMap2 = DefaultLiveMap.createZeroValued(delegate: delegate, coreSDK: coreSDK)
-            let existingCounter = DefaultLiveCounter.createZeroValued(coreSDK: coreSDK)
+            let existingMap1 = DefaultLiveMap.createZeroValued(objectID: "arbitrary", delegate: delegate, coreSDK: coreSDK)
+            let existingMap2 = DefaultLiveMap.createZeroValued(objectID: "arbitrary", delegate: delegate, coreSDK: coreSDK)
+            let existingCounter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: coreSDK)
 
             var pool = ObjectsPool(rootDelegate: delegate, rootCoreSDK: coreSDK, testsOnly_otherEntries: [
                 "map:hash@1": .map(existingMap1),
@@ -250,7 +250,7 @@ struct ObjectsPoolTests {
         func doesNotRemoveRootObject() throws {
             let delegate = MockLiveMapObjectPoolDelegate()
             let coreSDK = MockCoreSDK(channelState: .attaching)
-            let existingMap = DefaultLiveMap.createZeroValued(delegate: delegate, coreSDK: coreSDK)
+            let existingMap = DefaultLiveMap.createZeroValued(objectID: "arbitrary", delegate: delegate, coreSDK: coreSDK)
             var pool = ObjectsPool(rootDelegate: delegate, rootCoreSDK: coreSDK, testsOnly_otherEntries: ["map:hash@1": .map(existingMap)])
             let logger = TestLogger()
 
@@ -269,9 +269,9 @@ struct ObjectsPoolTests {
             let delegate = MockLiveMapObjectPoolDelegate()
             let coreSDK = MockCoreSDK(channelState: .attaching)
 
-            let existingMap = DefaultLiveMap.createZeroValued(delegate: delegate, coreSDK: coreSDK)
-            let existingCounter = DefaultLiveCounter.createZeroValued(coreSDK: coreSDK)
-            let toBeRemovedMap = DefaultLiveMap.createZeroValued(delegate: delegate, coreSDK: coreSDK)
+            let existingMap = DefaultLiveMap.createZeroValued(objectID: "arbitrary", delegate: delegate, coreSDK: coreSDK)
+            let existingCounter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: coreSDK)
+            let toBeRemovedMap = DefaultLiveMap.createZeroValued(objectID: "arbitrary", delegate: delegate, coreSDK: coreSDK)
 
             var pool = ObjectsPool(rootDelegate: delegate, rootCoreSDK: coreSDK, testsOnly_otherEntries: [
                 "map:existing@1": .map(existingMap),


### PR DESCRIPTION
**Note: This PR is based on top of #22; please review that one first.**

Implements the behaviours specified in https://github.com/ably/specification/pull/343, except for buffering during a sync, which we have a separate task for. See commit messages for more details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling and application of object protocol messages, including structured and logged processing of map and counter operations.
  * Enhanced thread safety for object message processing.
  * Unified and centralized mutable state management for live objects.
  * Added detailed logging throughout object creation and operation application.

* **Bug Fixes**
  * Ensured consistent logging capability during object creation and operation handling.

* **Tests**
  * Expanded and refactored test coverage for map and counter operations, including initial value merging, operation application, and edge cases.
  * Added comprehensive tests for protocol message handling and operation applicability logic.
  * Introduced new test factories for streamlined creation of test objects and operations.

* **Chores**
  * Updated all test cases to use explicit logger parameters for improved traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->