### PR TITLE
Use an abstract channel

### DIFF
--- a/Sources/AblyLiveObjects/Internal/CoreSDK.swift
+++ b/Sources/AblyLiveObjects/Internal/CoreSDK.swift
@@ -13,11 +13,11 @@ internal protocol CoreSDK: AnyObject, Sendable {
 
 internal final class DefaultCoreSDK: CoreSDK {
     // We hold a weak reference to the channel so that `DefaultLiveObjects` can hold a strong reference to us without causing a strong reference cycle. We'll revisit this in https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/9.
-    private let weakChannel: WeakRef<ARTRealtimeChannel>
+    private let weakChannel: WeakRef<AblyPlugin.RealtimeChannel>
     private let pluginAPI: PluginAPIProtocol
 
     internal init(
-        channel: ARTRealtimeChannel,
+        channel: AblyPlugin.RealtimeChannel,
         pluginAPI: PluginAPIProtocol
     ) {
         weakChannel = .init(referenced: channel)
@@ -26,7 +26,7 @@ internal final class DefaultCoreSDK: CoreSDK {
 
     // MARK: - Fetching channel
 
-    private var channel: ARTRealtimeChannel {
+    private var channel: AblyPlugin.RealtimeChannel {
         guard let channel = weakChannel.referenced else {
             // It's currently completely possible that the channel _does_ become deallocated during the usage of the LiveObjects SDK; in https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/9 we'll figure out how to prevent this.
             preconditionFailure("Expected channel to not become deallocated during usage of LiveObjects SDK")


### PR DESCRIPTION
**Note: This PR is based on top of #24; please review that one first.**

This brings us in line with the AblyPlugin API changes that come in the accompanying ably-cocoa submodule update (https://github.com/ably/ably-cocoa/pull/2073).