### PR TITLE
[ECO-5384] Implement memory management pattern similar to ably-cocoa

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -56,6 +56,14 @@ let package = Package(
             name: "AblyLiveObjectsTests",
             dependencies: [
                 "AblyLiveObjects",
+                .product(
+                    name: "Ably",
+                    package: "ably-cocoa",
+                ),
+                .product(
+                    name: "AblyPlugin",
+                    package: "ably-cocoa",
+                ),
             ],
             resources: [
                 .copy("ably-common"),

--- a/Sources/AblyLiveObjects/Internal/CoreSDK.swift
+++ b/Sources/AblyLiveObjects/Internal/CoreSDK.swift
@@ -12,27 +12,18 @@ internal protocol CoreSDK: AnyObject, Sendable {
 }
 
 internal final class DefaultCoreSDK: CoreSDK {
-    // We hold a weak reference to the channel so that `DefaultLiveObjects` can hold a strong reference to us without causing a strong reference cycle. We'll revisit this in https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/9.
-    private let weakChannel: WeakRef<AblyPlugin.RealtimeChannel>
+    private let channel: AblyPlugin.RealtimeChannel
+    private let client: AblyPlugin.RealtimeClient
     private let pluginAPI: PluginAPIProtocol
 
     internal init(
         channel: AblyPlugin.RealtimeChannel,
+        client: AblyPlugin.RealtimeClient,
         pluginAPI: PluginAPIProtocol
     ) {
-        weakChannel = .init(referenced: channel)
+        self.channel = channel
+        self.client = client
         self.pluginAPI = pluginAPI
-    }
-
-    // MARK: - Fetching channel
-
-    private var channel: AblyPlugin.RealtimeChannel {
-        guard let channel = weakChannel.referenced else {
-            // It's currently completely possible that the channel _does_ become deallocated during the usage of the LiveObjects SDK; in https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/9 we'll figure out how to prevent this.
-            preconditionFailure("Expected channel to not become deallocated during usage of LiveObjects SDK")
-        }
-
-        return channel
     }
 
     // MARK: - CoreSDK conformance

--- a/Sources/AblyLiveObjects/Internal/DefaultInternalPlugin.swift
+++ b/Sources/AblyLiveObjects/Internal/DefaultInternalPlugin.swift
@@ -17,25 +17,17 @@ internal final class DefaultInternalPlugin: NSObject, AblyPlugin.LiveObjectsInte
     /// The `pluginDataValue(forKey:channel:)` key that we use to store the value of the `ARTRealtimeChannel.objects` property.
     private static let pluginDataKey = "LiveObjects"
 
-    /// Retrieves the value that should be returned by `ARTRealtimeChannel.objects`.
-    ///
-    /// We expect this value to have been previously set by ``prepare(_:)``.
-    internal static func objectsProperty(for channel: ARTRealtimeChannel, pluginAPI: AblyPlugin.PluginAPIProtocol) -> DefaultRealtimeObjects {
-        let underlyingObjects = pluginAPI.underlyingObjects(forPublicRealtimeChannel: channel)
-        return realtimeObjects(for: underlyingObjects.channel, pluginAPI: pluginAPI)
-    }
-
     /// Retrieves the `RealtimeObjects` for this channel.
     ///
     /// We expect this value to have been previously set by ``prepare(_:)``.
-    private static func realtimeObjects(for channel: AblyPlugin.RealtimeChannel, pluginAPI: AblyPlugin.PluginAPIProtocol) -> DefaultRealtimeObjects {
+    internal static func realtimeObjects(for channel: AblyPlugin.RealtimeChannel, pluginAPI: AblyPlugin.PluginAPIProtocol) -> InternalDefaultRealtimeObjects {
         guard let pluginData = pluginAPI.pluginDataValue(forKey: pluginDataKey, channel: channel) else {
             // InternalPlugin.prepare was not called
             fatalError("To access LiveObjects functionality, you must pass the LiveObjects plugin in the client options when creating the ARTRealtime instance: `clientOptions.plugins = [.liveObjects: AblyLiveObjects.Plugin.self]`")
         }
 
         // swiftlint:disable:next force_cast
-        return pluginData as! DefaultRealtimeObjects
+        return pluginData as! InternalDefaultRealtimeObjects
     }
 
     // MARK: - LiveObjectsInternalPluginProtocol
@@ -45,13 +37,12 @@ internal final class DefaultInternalPlugin: NSObject, AblyPlugin.LiveObjectsInte
         let logger = pluginAPI.logger(for: channel)
 
         logger.log("LiveObjects.DefaultInternalPlugin received prepare(_:)", level: .debug)
-        let coreSDK = DefaultCoreSDK(channel: channel, pluginAPI: pluginAPI)
-        let liveObjects = DefaultRealtimeObjects(coreSDK: coreSDK, logger: logger)
+        let liveObjects = InternalDefaultRealtimeObjects(logger: logger)
         pluginAPI.setPluginDataValue(liveObjects, forKey: Self.pluginDataKey, channel: channel)
     }
 
     /// Retrieves the internally-typed `objects` property for the channel.
-    private func realtimeObjects(for channel: AblyPlugin.RealtimeChannel) -> DefaultRealtimeObjects {
+    private func realtimeObjects(for channel: AblyPlugin.RealtimeChannel) -> InternalDefaultRealtimeObjects {
         Self.realtimeObjects(for: channel, pluginAPI: pluginAPI)
     }
 

--- a/Sources/AblyLiveObjects/Internal/DefaultInternalPlugin.swift
+++ b/Sources/AblyLiveObjects/Internal/DefaultInternalPlugin.swift
@@ -21,8 +21,8 @@ internal final class DefaultInternalPlugin: NSObject, AblyPlugin.LiveObjectsInte
     ///
     /// We expect this value to have been previously set by ``prepare(_:)``.
     internal static func objectsProperty(for channel: ARTRealtimeChannel, pluginAPI: AblyPlugin.PluginAPIProtocol) -> DefaultRealtimeObjects {
-        let pluginChannel = pluginAPI.channel(forPublicRealtimeChannel: channel)
-        return realtimeObjects(for: pluginChannel, pluginAPI: pluginAPI)
+        let underlyingObjects = pluginAPI.underlyingObjects(forPublicRealtimeChannel: channel)
+        return realtimeObjects(for: underlyingObjects.channel, pluginAPI: pluginAPI)
     }
 
     /// Retrieves the `RealtimeObjects` for this channel.
@@ -41,7 +41,7 @@ internal final class DefaultInternalPlugin: NSObject, AblyPlugin.LiveObjectsInte
     // MARK: - LiveObjectsInternalPluginProtocol
 
     // Populates the channel's `objects` property.
-    internal func prepare(_ channel: AblyPlugin.RealtimeChannel) {
+    internal func prepare(_ channel: AblyPlugin.RealtimeChannel, client _: AblyPlugin.RealtimeClient) {
         let logger = pluginAPI.logger(for: channel)
 
         logger.log("LiveObjects.DefaultInternalPlugin received prepare(_:)", level: .debug)

--- a/Sources/AblyLiveObjects/Internal/InternalLiveMapValue.swift
+++ b/Sources/AblyLiveObjects/Internal/InternalLiveMapValue.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Same as the public ``LiveMapValue`` type but with associated values of internal type.
+internal enum InternalLiveMapValue: Sendable {
+    case primitive(PrimitiveObjectValue)
+    case liveMap(InternalDefaultLiveMap)
+    case liveCounter(InternalDefaultLiveCounter)
+
+    // MARK: - Convenience getters for associated values
+
+    /// If this `InternalLiveMapValue` has case `primitive`, this returns the associated value. Else, it returns `nil`.
+    internal var primitiveValue: PrimitiveObjectValue? {
+        if case let .primitive(value) = self {
+            return value
+        }
+        return nil
+    }
+
+    /// If this `InternalLiveMapValue` has case `liveMap`, this returns the associated value. Else, it returns `nil`.
+    internal var liveMapValue: InternalDefaultLiveMap? {
+        if case let .liveMap(value) = self {
+            return value
+        }
+        return nil
+    }
+
+    /// If this `InternalLiveMapValue` has case `liveCounter`, this returns the associated value. Else, it returns `nil`.
+    internal var liveCounterValue: InternalDefaultLiveCounter? {
+        if case let .liveCounter(value) = self {
+            return value
+        }
+        return nil
+    }
+
+    /// If this `InternalLiveMapValue` has case `primitive` with a string value, this returns that value. Else, it returns `nil`.
+    internal var stringValue: String? {
+        primitiveValue?.stringValue
+    }
+
+    /// If this `InternalLiveMapValue` has case `primitive` with a number value, this returns that value. Else, it returns `nil`.
+    internal var numberValue: Double? {
+        primitiveValue?.numberValue
+    }
+
+    /// If this `InternalLiveMapValue` has case `primitive` with a boolean value, this returns that value. Else, it returns `nil`.
+    internal var boolValue: Bool? {
+        primitiveValue?.boolValue
+    }
+
+    /// If this `InternalLiveMapValue` has case `primitive` with a data value, this returns that value. Else, it returns `nil`.
+    internal var dataValue: Data? {
+        primitiveValue?.dataValue
+    }
+}

--- a/Sources/AblyLiveObjects/Internal/LiveObjectMutableState.swift
+++ b/Sources/AblyLiveObjects/Internal/LiveObjectMutableState.swift
@@ -2,7 +2,7 @@ internal import AblyPlugin
 
 /// This is the equivalent of the `LiveObject` abstract class described in RTLO.
 ///
-/// ``DefaultLiveCounter`` and ``DefaultLiveMap`` include it by composition.
+/// ``InternalDefaultLiveCounter`` and ``InternalDefaultLiveMap`` include it by composition.
 internal struct LiveObjectMutableState {
     // RTLO3a
     internal var objectID: String

--- a/Sources/AblyLiveObjects/Public/ARTRealtimeChannel+Objects.swift
+++ b/Sources/AblyLiveObjects/Public/ARTRealtimeChannel+Objects.swift
@@ -4,15 +4,30 @@ internal import AblyPlugin
 public extension ARTRealtimeChannel {
     /// A ``RealtimeObjects`` object.
     var objects: RealtimeObjects {
-        internallyTypedObjects
+        nonTypeErasedObjects
     }
 
-    private var internallyTypedObjects: DefaultRealtimeObjects {
-        DefaultInternalPlugin.objectsProperty(for: self, pluginAPI: AblyPlugin.PluginAPI.sharedInstance())
+    private var nonTypeErasedObjects: PublicDefaultRealtimeObjects {
+        let pluginAPI = Plugin.defaultPluginAPI
+        let underlyingObjects = pluginAPI.underlyingObjects(forPublicRealtimeChannel: self)
+        let internalObjects = DefaultInternalPlugin.realtimeObjects(for: underlyingObjects.channel, pluginAPI: pluginAPI)
+
+        let coreSDK = DefaultCoreSDK(
+            channel: underlyingObjects.channel,
+            client: underlyingObjects.client,
+            pluginAPI: Plugin.defaultPluginAPI,
+        )
+
+        return PublicObjectsStore.shared.getOrCreateRealtimeObjects(
+            proxying: internalObjects,
+            creationArgs: .init(
+                coreSDK: coreSDK,
+            ),
+        )
     }
 
-    /// For tests to access the non-public API of `DefaultRealtimeObjects`.
-    internal var testsOnly_internallyTypedObjects: DefaultRealtimeObjects {
-        internallyTypedObjects
+    /// For tests to access the non-public API of `PublicDefaultRealtimeObjects`.
+    internal var testsOnly_nonTypeErasedObjects: PublicDefaultRealtimeObjects {
+        nonTypeErasedObjects
     }
 }

--- a/Sources/AblyLiveObjects/Public/Plugin.swift
+++ b/Sources/AblyLiveObjects/Public/Plugin.swift
@@ -22,7 +22,10 @@ import ObjectiveC.NSObject
 /// ```
 @objc
 public class Plugin: NSObject {
+    /// The `AblyPlugin.PluginAPIProtocol` that the LiveObjects plugin should use by default (i.e. when one hasn't been injected for test purposes).
+    internal static let defaultPluginAPI: AblyPlugin.PluginAPIProtocol = AblyPlugin.PluginAPI.sharedInstance()
+
     // MARK: - Informal conformance to AblyPlugin.LiveObjectsPluginProtocol
 
-    @objc private static let internalPlugin = DefaultInternalPlugin(pluginAPI: AblyPlugin.PluginAPI.sharedInstance())
+    @objc private static let internalPlugin = DefaultInternalPlugin(pluginAPI: defaultPluginAPI)
 }

--- a/Sources/AblyLiveObjects/Public/Public Proxy Objects/InternalLiveMapValue+ToPublic.swift
+++ b/Sources/AblyLiveObjects/Public/Public Proxy Objects/InternalLiveMapValue+ToPublic.swift
@@ -1,0 +1,38 @@
+internal extension InternalLiveMapValue {
+    // MARK: - Mapping to public types
+
+    struct PublicValueCreationArgs {
+        internal var coreSDK: CoreSDK
+        internal var mapDelegate: LiveMapObjectPoolDelegate
+
+        internal var toCounterCreationArgs: PublicObjectsStore.CounterCreationArgs {
+            .init(coreSDK: coreSDK)
+        }
+
+        internal var toMapCreationArgs: PublicObjectsStore.MapCreationArgs {
+            .init(coreSDK: coreSDK, delegate: mapDelegate)
+        }
+    }
+
+    /// Fetches the cached public object that wraps this `InternalLiveMapValue`'s associated value, creating a new public object if there isn't already one.
+    func toPublic(creationArgs: PublicValueCreationArgs) -> LiveMapValue {
+        switch self {
+        case let .primitive(primitive):
+            .primitive(primitive)
+        case let .liveMap(internalLiveMap):
+            .liveMap(
+                PublicObjectsStore.shared.getOrCreateMap(
+                    proxying: internalLiveMap,
+                    creationArgs: creationArgs.toMapCreationArgs,
+                ),
+            )
+        case let .liveCounter(internalLiveCounter):
+            .liveCounter(
+                PublicObjectsStore.shared.getOrCreateCounter(
+                    proxying: internalLiveCounter,
+                    creationArgs: creationArgs.toCounterCreationArgs,
+                ),
+            )
+        }
+    }
+}

--- a/Sources/AblyLiveObjects/Public/Public Proxy Objects/PublicDefaultLiveCounter.swift
+++ b/Sources/AblyLiveObjects/Public/Public Proxy Objects/PublicDefaultLiveCounter.swift
@@ -1,0 +1,52 @@
+import Ably
+
+/// Our default implementation of ``LiveCounter``.
+///
+/// This is largely a wrapper around ``InternalDefaultLiveCounter``.
+internal final class PublicDefaultLiveCounter: LiveCounter {
+    private let proxied: InternalDefaultLiveCounter
+    internal var testsOnly_proxied: InternalDefaultLiveCounter {
+        proxied
+    }
+
+    // MARK: - Dependencies that hold a strong reference to `proxied`
+
+    private let coreSDK: CoreSDK
+
+    internal init(proxied: InternalDefaultLiveCounter, coreSDK: CoreSDK) {
+        self.proxied = proxied
+        self.coreSDK = coreSDK
+    }
+
+    // MARK: - `LiveCounter` protocol
+
+    internal var value: Double {
+        get throws(ARTErrorInfo) {
+            try proxied.value(coreSDK: coreSDK)
+        }
+    }
+
+    internal func increment(amount: Double) async throws(ARTErrorInfo) {
+        try await proxied.increment(amount: amount)
+    }
+
+    internal func decrement(amount: Double) async throws(ARTErrorInfo) {
+        try await proxied.decrement(amount: amount)
+    }
+
+    internal func subscribe(listener: sending (sending any LiveCounterUpdate) -> Void) -> any SubscribeResponse {
+        proxied.subscribe(listener: listener)
+    }
+
+    internal func unsubscribeAll() {
+        proxied.unsubscribeAll()
+    }
+
+    internal func on(event: LiveObjectLifecycleEvent, callback: sending () -> Void) -> any OnLiveObjectLifecycleEventResponse {
+        proxied.on(event: event, callback: callback)
+    }
+
+    internal func offAll() {
+        proxied.offAll()
+    }
+}

--- a/Sources/AblyLiveObjects/Public/Public Proxy Objects/PublicDefaultRealtimeObjects.swift
+++ b/Sources/AblyLiveObjects/Public/Public Proxy Objects/PublicDefaultRealtimeObjects.swift
@@ -1,0 +1,81 @@
+import Ably
+
+/// The class that provides the public API for interacting with LiveObjects, via the ``ARTRealtimeChannel/objects`` property.
+///
+/// This is largely a wrapper around ``InternalDefaultRealtimeObjects``.
+internal final class PublicDefaultRealtimeObjects: RealtimeObjects {
+    private let proxied: InternalDefaultRealtimeObjects
+    internal var testsOnly_proxied: InternalDefaultRealtimeObjects {
+        proxied
+    }
+
+    // MARK: - Dependencies that hold a strong reference to `proxied`
+
+    private let coreSDK: CoreSDK
+
+    internal init(proxied: InternalDefaultRealtimeObjects, coreSDK: CoreSDK) {
+        self.proxied = proxied
+        self.coreSDK = coreSDK
+    }
+
+    // MARK: - `RealtimeObjects` protocol
+
+    internal func getRoot() async throws(ARTErrorInfo) -> any LiveMap {
+        let internalMap = try await proxied.getRoot(coreSDK: coreSDK)
+        return PublicObjectsStore.shared.getOrCreateMap(
+            proxying: internalMap,
+            creationArgs: .init(
+                coreSDK: coreSDK,
+                delegate: proxied,
+            ),
+        )
+    }
+
+    internal func createMap(entries: [String: LiveMapValue]) async throws(ARTErrorInfo) -> any LiveMap {
+        try await proxied.createMap(entries: entries)
+    }
+
+    internal func createMap() async throws(ARTErrorInfo) -> any LiveMap {
+        try await proxied.createMap()
+    }
+
+    internal func createCounter(count: Double) async throws(ARTErrorInfo) -> any LiveCounter {
+        try await proxied.createCounter(count: count)
+    }
+
+    internal func createCounter() async throws(ARTErrorInfo) -> any LiveCounter {
+        try await proxied.createCounter()
+    }
+
+    internal func batch(callback: sending (sending any BatchContext) -> Void) async throws {
+        try await proxied.batch(callback: callback)
+    }
+
+    internal func on(event: ObjectsEvent, callback: sending () -> Void) -> any OnObjectsEventResponse {
+        proxied.on(event: event, callback: callback)
+    }
+
+    internal func offAll() {
+        proxied.offAll()
+    }
+
+    // MARK: - Test-only APIs
+
+    // These are only used by our plumbingSmokeTest (the rest of our unit tests test the internal classes, not the public ones).
+
+    internal var testsOnly_onChannelAttachedHasObjects: Bool? {
+        proxied.testsOnly_onChannelAttachedHasObjects
+    }
+
+    internal var testsOnly_receivedObjectProtocolMessages: AsyncStream<[InboundObjectMessage]> {
+        proxied.testsOnly_receivedObjectProtocolMessages
+    }
+
+    internal func testsOnly_sendObject(objectMessages: [OutboundObjectMessage]) async throws(InternalError) {
+        try await proxied.testsOnly_sendObject(objectMessages: objectMessages, coreSDK: coreSDK)
+    }
+
+    internal var testsOnly_receivedObjectSyncProtocolMessages: AsyncStream<[InboundObjectMessage]> {
+        proxied.testsOnly_receivedObjectSyncProtocolMessages
+    }
+}

--- a/Sources/AblyLiveObjects/Public/Public Proxy Objects/PublicObjectsStore.swift
+++ b/Sources/AblyLiveObjects/Public/Public Proxy Objects/PublicObjectsStore.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+/// Stores the public objects that wrap the SDK's internal components.
+///
+/// This allows us to provide stable object identity for our public `RealtimeObjects`, `LiveMap`, and `LiveCounter` objects. Concretely, this means that it allows us to, for example, consistently return:
+///
+/// - the same `PublicDefaultRealtimeObjects` instance across multiple calls to `ARTRealtimeChannel.objects`
+/// - the same `PublicDefaultLiveMap` instance across multiple calls to `PublicDefaultRealtimeObjects.getRoot()`
+/// - the same `PublicDefaultLiveMap` and `PublicDefaultLiveCounter` instance across multiple calls to `PublicDefaultLiveMap.get(…)` with the same key (similarly for other `LiveMap` getters)
+///
+/// This differs from the approach that we take in ably-cocoa, in which we create a new public object each time we need to return one. Given that the LiveObjects SDK revolves around the concept of various live-updating objects, it seemed like it might be quite a confusing user experience if the pointer identity of, say, a `LiveMap` changed each time it was fetched.
+///
+/// - Note: We can only make a best-effort attempt to maintain the pointer identity of the public objects. Since the SDK cannot maintain a strong reference to the public objects (given that the whole reason that these objects exist is for us to know whether the user holds a strong reference to them), if the user releases all of their strong references to a public object then the next time they fetch the public object they will receive a new object.
+internal final class PublicObjectsStore: Sendable {
+    // Used to synchronize access to mutable state
+    private let mutex = NSLock()
+    private nonisolated(unsafe) var mutableState = MutableState()
+
+    internal static let shared = PublicObjectsStore()
+
+    internal struct RealtimeObjectsCreationArgs {
+        internal var coreSDK: CoreSDK
+    }
+
+    /// Fetches the cached `PublicDefaultRealtimeObjects` that wraps a given `InternalDefaultRealtimeObjects`, creating a new public object if there isn't already one.
+    internal func getOrCreateRealtimeObjects(proxying proxied: InternalDefaultRealtimeObjects, creationArgs: RealtimeObjectsCreationArgs) -> PublicDefaultRealtimeObjects {
+        mutex.withLock {
+            mutableState.getOrCreateRealtimeObjects(proxying: proxied, creationArgs: creationArgs)
+        }
+    }
+
+    internal struct CounterCreationArgs {
+        internal var coreSDK: CoreSDK
+    }
+
+    /// Fetches the cached `PublicDefaultLiveCounter` that wraps a given `InternalDefaultLiveCounter`, creating a new public object if there isn't already one.
+    internal func getOrCreateCounter(proxying proxied: InternalDefaultLiveCounter, creationArgs: CounterCreationArgs) -> PublicDefaultLiveCounter {
+        mutex.withLock {
+            mutableState.getOrCreateCounter(proxying: proxied, creationArgs: creationArgs)
+        }
+    }
+
+    internal struct MapCreationArgs {
+        internal var coreSDK: CoreSDK
+        internal var delegate: LiveMapObjectPoolDelegate
+    }
+
+    /// Fetches the cached `PublicDefaultLiveMap` that wraps a given `InternalDefaultLiveMap`, creating a new public object if there isn't already one.
+    internal func getOrCreateMap(proxying proxied: InternalDefaultLiveMap, creationArgs: MapCreationArgs) -> PublicDefaultLiveMap {
+        mutex.withLock {
+            mutableState.getOrCreateMap(proxying: proxied, creationArgs: creationArgs)
+        }
+    }
+
+    private struct MutableState {
+        private var realtimeObjectsProxies = Proxies<PublicDefaultRealtimeObjects>()
+        private var counterProxies = Proxies<PublicDefaultLiveCounter>()
+        private var mapProxies = Proxies<PublicDefaultLiveMap>()
+
+        /// Stores weak references to proxy objects.
+        private struct Proxies<Proxy: AnyObject> {
+            private var proxiesByProxiedObjectIdentifier: [ObjectIdentifier: WeakRef<Proxy>] = [:]
+
+            /// Fetches the proxy that wraps `proxied`, creating a new proxy if there isn't already one. Stores a weak reference to the proxy.
+            mutating func getOrCreate(
+                proxying proxied: some AnyObject,
+                createProxy: () -> Proxy,
+            ) -> Proxy {
+                // Remove any entries that are no longer useful
+                removeDeallocatedEntries()
+
+                // Do the get-or-create
+                let proxiedObjectIdentifier = ObjectIdentifier(proxied)
+
+                if let existing = proxiesByProxiedObjectIdentifier[proxiedObjectIdentifier]?.referenced {
+                    return existing
+                }
+
+                let created = createProxy()
+                proxiesByProxiedObjectIdentifier[proxiedObjectIdentifier] = .init(referenced: created)
+
+                return created
+            }
+
+            private mutating func removeDeallocatedEntries() {
+                proxiesByProxiedObjectIdentifier = proxiesByProxiedObjectIdentifier.filter { entry in
+                    entry.value.referenced != nil
+                }
+            }
+        }
+
+        internal mutating func getOrCreateRealtimeObjects(
+            proxying proxied: InternalDefaultRealtimeObjects,
+            creationArgs: RealtimeObjectsCreationArgs,
+        ) -> PublicDefaultRealtimeObjects {
+            realtimeObjectsProxies.getOrCreate(proxying: proxied) {
+                .init(
+                    proxied: proxied,
+                    coreSDK: creationArgs.coreSDK,
+                )
+            }
+        }
+
+        internal mutating func getOrCreateCounter(
+            proxying proxied: InternalDefaultLiveCounter,
+            creationArgs: CounterCreationArgs,
+        ) -> PublicDefaultLiveCounter {
+            counterProxies.getOrCreate(proxying: proxied) {
+                .init(
+                    proxied: proxied,
+                    coreSDK: creationArgs.coreSDK,
+                )
+            }
+        }
+
+        internal mutating func getOrCreateMap(
+            proxying proxied: InternalDefaultLiveMap,
+            creationArgs: MapCreationArgs,
+        ) -> PublicDefaultLiveMap {
+            mapProxies.getOrCreate(proxying: proxied) {
+                .init(
+                    proxied: proxied,
+                    coreSDK: creationArgs.coreSDK,
+                    delegate: creationArgs.delegate,
+                )
+            }
+        }
+    }
+}

--- a/Sources/AblyLiveObjects/Utility/WeakRef.swift
+++ b/Sources/AblyLiveObjects/Utility/WeakRef.swift
@@ -6,11 +6,3 @@ internal struct WeakRef<Referenced: AnyObject> {
 }
 
 extension WeakRef: Sendable where Referenced: Sendable {}
-
-// MARK: - Specialized versions of WeakRef
-
-// These are protocol-specific versions of ``WeakRef`` that hold an existential type (e.g. `any CoreSDK`). (This is because the compiler complains that an existential of a class-bound protocol doesn't conform to `AnyObject`.)
-
-internal struct WeakLiveMapObjectPoolDelegateRef: Sendable {
-    internal weak var referenced: LiveMapObjectPoolDelegate?
-}

--- a/Tests/AblyLiveObjectsTests/Helpers/ClientHelper.swift
+++ b/Tests/AblyLiveObjectsTests/Helpers/ClientHelper.swift
@@ -1,0 +1,36 @@
+import Ably
+import AblyLiveObjects
+
+/// Helper for creating ably-cocoa objects, for use in integration tests.
+enum ClientHelper {
+    /// Creates a sandbox Realtime client with LiveObjects support.
+    static func realtimeWithObjects(options: PartialClientOptions = .init()) async throws -> ARTRealtime {
+        let key = try await Sandbox.fetchSharedAPIKey()
+        let clientOptions = ARTClientOptions(key: key)
+        clientOptions.plugins = [.liveObjects: AblyLiveObjects.Plugin.self]
+        clientOptions.environment = "sandbox"
+
+        clientOptions.testOptions.transportFactory = TestProxyTransportFactory()
+
+        if TestLogger.loggingEnabled {
+            clientOptions.logLevel = .verbose
+        }
+
+        if let useBinaryProtocol = options.useBinaryProtocol {
+            clientOptions.useBinaryProtocol = useBinaryProtocol
+        }
+
+        return ARTRealtime(options: clientOptions)
+    }
+
+    /// Creates channel options that include the channel modes needed for LiveObjects.
+    static func channelOptionsWithObjects() -> ARTRealtimeChannelOptions {
+        let options = ARTRealtimeChannelOptions()
+        options.modes = [.objectSubscribe, .objectPublish]
+        return options
+    }
+
+    struct PartialClientOptions: Encodable, Hashable {
+        var useBinaryProtocol: Bool?
+    }
+}

--- a/Tests/AblyLiveObjectsTests/Helpers/ClientHelper.swift
+++ b/Tests/AblyLiveObjectsTests/Helpers/ClientHelper.swift
@@ -19,6 +19,9 @@ enum ClientHelper {
         if let useBinaryProtocol = options.useBinaryProtocol {
             clientOptions.useBinaryProtocol = useBinaryProtocol
         }
+        if let autoConnect = options.autoConnect {
+            clientOptions.autoConnect = autoConnect
+        }
 
         return ARTRealtime(options: clientOptions)
     }
@@ -32,5 +35,6 @@ enum ClientHelper {
 
     struct PartialClientOptions: Encodable, Hashable {
         var useBinaryProtocol: Bool?
+        var autoConnect: Bool?
     }
 }

--- a/Tests/AblyLiveObjectsTests/Helpers/TestFactories.swift
+++ b/Tests/AblyLiveObjectsTests/Helpers/TestFactories.swift
@@ -172,14 +172,12 @@ import Foundation
 /// /// - Parameters:
 /// ///   - objectId: The object ID for the map (default: "map:test@123")
 /// ///   - entries: Dictionary of key-value pairs to populate the map
-/// ///   - delegate: The delegate for the map (default: MockLiveMapObjectPoolDelegate())
-/// /// - Returns: A configured DefaultLiveMap instance
+/// /// - Returns: A configured InternalDefaultLiveMap instance
 /// static func liveMap(
 ///     objectId: String = "map:test@123",
 ///     entries: [String: String] = [:],
-///     delegate: LiveMapObjectPoolDelegate = MockLiveMapObjectPoolDelegate()
-/// ) -> DefaultLiveMap {
-///     let map = DefaultLiveMap.createZeroValued(delegate: delegate)
+/// ) -> InternalDefaultLiveMap {
+///     let map = InternalDefaultLiveMap.createZeroValued()
 ///     // Configure map with entries...
 ///     return map
 /// }

--- a/Tests/AblyLiveObjectsTests/InternalDefaultLiveCounterTests.swift
+++ b/Tests/AblyLiveObjectsTests/InternalDefaultLiveCounterTests.swift
@@ -3,17 +3,18 @@ import AblyPlugin
 import Foundation
 import Testing
 
-struct DefaultLiveCounterTests {
+struct InternalDefaultLiveCounterTests {
     /// Tests for the `value` property, covering RTLC5 specification points
     struct ValueTests {
         // @spec RTLC5b
         @Test(arguments: [.detached, .failed] as [ARTRealtimeChannelState])
         func valueThrowsIfChannelIsDetachedOrFailed(channelState: ARTRealtimeChannelState) async throws {
             let logger = TestLogger()
-            let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: channelState), logger: logger)
+            let counter = InternalDefaultLiveCounter.createZeroValued(objectID: "arbitrary", logger: logger)
+            let coreSDK = MockCoreSDK(channelState: channelState)
 
             #expect {
-                _ = try counter.value
+                _ = try counter.value(coreSDK: coreSDK)
             } throws: { error in
                 guard let errorInfo = error as? ARTErrorInfo else {
                     return false
@@ -27,12 +28,13 @@ struct DefaultLiveCounterTests {
         @Test
         func valueReturnsCurrentDataWhenChannelIsValid() throws {
             let logger = TestLogger()
-            let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attached), logger: logger)
+            let counter = InternalDefaultLiveCounter.createZeroValued(objectID: "arbitrary", logger: logger)
+            let coreSDK = MockCoreSDK(channelState: .attached)
 
             // Set some test data
             counter.replaceData(using: TestFactories.counterObjectState(count: 42))
 
-            #expect(try counter.value == 42)
+            #expect(try counter.value(coreSDK: coreSDK) == 42)
         }
     }
 
@@ -42,7 +44,7 @@ struct DefaultLiveCounterTests {
         @Test
         func replacesSiteTimeserials() {
             let logger = TestLogger()
-            let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attaching), logger: logger)
+            let counter = InternalDefaultLiveCounter.createZeroValued(objectID: "arbitrary", logger: logger)
             let state = TestFactories.counterObjectState(
                 siteTimeserials: ["site1": "ts1"], // Test value
             )
@@ -58,7 +60,7 @@ struct DefaultLiveCounterTests {
                 // Given: A counter whose createOperationIsMerged is true
                 let logger = TestLogger()
                 let counter = {
-                    let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attaching), logger: logger)
+                    let counter = InternalDefaultLiveCounter.createZeroValued(objectID: "arbitrary", logger: logger)
                     // Test setup: Manipulate counter so that its createOperationIsMerged gets set to true (we need to do this since we want to later assert that it gets set to false, but the default is false).
                     let state = TestFactories.counterObjectState(
                         createOp: TestFactories.objectOperation(
@@ -85,23 +87,25 @@ struct DefaultLiveCounterTests {
             @Test
             func setsDataToCounterCount() throws {
                 let logger = TestLogger()
-                let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attaching), logger: logger)
+                let counter = InternalDefaultLiveCounter.createZeroValued(objectID: "arbitrary", logger: logger)
+                let coreSDK = MockCoreSDK(channelState: .attaching)
                 let state = TestFactories.counterObjectState(
                     count: 42, // Test value
                 )
                 counter.replaceData(using: state)
-                #expect(try counter.value == 42)
+                #expect(try counter.value(coreSDK: coreSDK) == 42)
             }
 
             // @specOneOf(2/4) RTLC6c - no count, no createOp
             @Test
             func setsDataToZeroWhenCounterCountDoesNotExist() throws {
                 let logger = TestLogger()
-                let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attaching), logger: logger)
+                let counter = InternalDefaultLiveCounter.createZeroValued(objectID: "arbitrary", logger: logger)
+                let coreSDK = MockCoreSDK(channelState: .attaching)
                 counter.replaceData(using: TestFactories.counterObjectState(
                     count: nil, // Test value - must be nil
                 ))
-                #expect(try counter.value == 0)
+                #expect(try counter.value(coreSDK: coreSDK) == 0)
             }
         }
 
@@ -111,13 +115,14 @@ struct DefaultLiveCounterTests {
             @Test
             func mergesInitialValueWhenCreateOpPresent() throws {
                 let logger = TestLogger()
-                let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attaching), logger: logger)
+                let counter = InternalDefaultLiveCounter.createZeroValued(objectID: "arbitrary", logger: logger)
+                let coreSDK = MockCoreSDK(channelState: .attaching)
                 let state = TestFactories.counterObjectState(
                     createOp: TestFactories.counterCreateOperation(count: 10), // Test value - must exist
                     count: 5, // Test value - must exist
                 )
                 counter.replaceData(using: state)
-                #expect(try counter.value == 15) // First sets to 5 (RTLC6c) then adds 10 (RTLC10a)
+                #expect(try counter.value(coreSDK: coreSDK) == 15) // First sets to 5 (RTLC6c) then adds 10 (RTLC10a)
                 #expect(counter.testsOnly_createOperationIsMerged)
             }
         }
@@ -129,28 +134,30 @@ struct DefaultLiveCounterTests {
         @Test
         func addsCounterCountToData() throws {
             let logger = TestLogger()
-            let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attaching), logger: logger)
+            let counter = InternalDefaultLiveCounter.createZeroValued(objectID: "arbitrary", logger: logger)
+            let coreSDK = MockCoreSDK(channelState: .attaching)
 
             // Set initial data
             counter.replaceData(using: TestFactories.counterObjectState(count: 5))
-            #expect(try counter.value == 5)
+            #expect(try counter.value(coreSDK: coreSDK) == 5)
 
             // Apply merge operation
             let operation = TestFactories.counterCreateOperation(count: 10) // Test value - must exist
             counter.testsOnly_mergeInitialValue(from: operation)
 
-            #expect(try counter.value == 15) // 5 + 10
+            #expect(try counter.value(coreSDK: coreSDK) == 15) // 5 + 10
         }
 
         // @specOneOf(2/2) RTLC10a - no count
         @Test
         func doesNotModifyDataWhenCounterCountDoesNotExist() throws {
             let logger = TestLogger()
-            let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attaching), logger: logger)
+            let counter = InternalDefaultLiveCounter.createZeroValued(objectID: "arbitrary", logger: logger)
+            let coreSDK = MockCoreSDK(channelState: .attaching)
 
             // Set initial data
             counter.replaceData(using: TestFactories.counterObjectState(count: 5))
-            #expect(try counter.value == 5)
+            #expect(try counter.value(coreSDK: coreSDK) == 5)
 
             // Apply merge operation with no count
             let operation = TestFactories.objectOperation(
@@ -159,14 +166,14 @@ struct DefaultLiveCounterTests {
             )
             counter.testsOnly_mergeInitialValue(from: operation)
 
-            #expect(try counter.value == 5) // Unchanged
+            #expect(try counter.value(coreSDK: coreSDK) == 5) // Unchanged
         }
 
         // @spec RTLC10b
         @Test
         func setsCreateOperationIsMergedToTrue() {
             let logger = TestLogger()
-            let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attaching), logger: logger)
+            let counter = InternalDefaultLiveCounter.createZeroValued(objectID: "arbitrary", logger: logger)
 
             // Apply merge operation
             let operation = TestFactories.counterCreateOperation(count: 10) // Test value - must exist
@@ -182,7 +189,8 @@ struct DefaultLiveCounterTests {
         @Test
         func discardsOperationWhenCreateOperationIsMerged() throws {
             let logger = TestLogger()
-            let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attaching), logger: logger)
+            let counter = InternalDefaultLiveCounter.createZeroValued(objectID: "arbitrary", logger: logger)
+            let coreSDK = MockCoreSDK(channelState: .attaching)
 
             // Set initial data and mark create operation as merged
             counter.replaceData(using: TestFactories.counterObjectState(count: 5))
@@ -194,14 +202,15 @@ struct DefaultLiveCounterTests {
             counter.testsOnly_applyCounterCreateOperation(operation)
 
             // Verify the operation was discarded - data unchanged
-            #expect(try counter.value == 15) // 5 + 10, not 5 + 10 + 20
+            #expect(try counter.value(coreSDK: coreSDK) == 15) // 5 + 10, not 5 + 10 + 20
         }
 
         // @spec RTLC8c
         @Test
         func mergesInitialValue() throws {
             let logger = TestLogger()
-            let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attaching), logger: logger)
+            let counter = InternalDefaultLiveCounter.createZeroValued(objectID: "arbitrary", logger: logger)
+            let coreSDK = MockCoreSDK(channelState: .attaching)
 
             // Set initial data but don't mark create operation as merged
             counter.replaceData(using: TestFactories.counterObjectState(count: 5))
@@ -212,7 +221,7 @@ struct DefaultLiveCounterTests {
             counter.testsOnly_applyCounterCreateOperation(operation)
 
             // Verify the operation was applied - initial value merged. (The full logic of RTLC10 is tested elsewhere; we just check for some of its side effects here.)
-            #expect(try counter.value == 15) // 5 + 10
+            #expect(try counter.value(coreSDK: coreSDK) == 15) // 5 + 10
             #expect(counter.testsOnly_createOperationIsMerged)
         }
     }
@@ -226,17 +235,18 @@ struct DefaultLiveCounterTests {
         ] as [(operation: WireObjectsCounterOp?, expectedValue: Double)])
         func addsAmountToData(operation: WireObjectsCounterOp?, expectedValue: Double) throws {
             let logger = TestLogger()
-            let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attaching), logger: logger)
+            let counter = InternalDefaultLiveCounter.createZeroValued(objectID: "arbitrary", logger: logger)
+            let coreSDK = MockCoreSDK(channelState: .attaching)
 
             // Set initial data
             counter.replaceData(using: TestFactories.counterObjectState(count: 5))
-            #expect(try counter.value == 5)
+            #expect(try counter.value(coreSDK: coreSDK) == 5)
 
             // Apply COUNTER_INC operation
             counter.testsOnly_applyCounterIncOperation(operation)
 
             // Verify the operation was applied correctly
-            #expect(try counter.value == expectedValue)
+            #expect(try counter.value(coreSDK: coreSDK) == expectedValue)
         }
     }
 
@@ -246,7 +256,8 @@ struct DefaultLiveCounterTests {
         @Test
         func discardsOperationWhenCannotBeApplied() throws {
             let logger = TestLogger()
-            let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attaching), logger: logger)
+            let counter = InternalDefaultLiveCounter.createZeroValued(objectID: "arbitrary", logger: logger)
+            let coreSDK = MockCoreSDK(channelState: .attaching)
 
             // Set up the counter with an existing site timeserial that will cause the operation to be discarded
             counter.replaceData(using: TestFactories.counterObjectState(
@@ -258,7 +269,7 @@ struct DefaultLiveCounterTests {
                 action: .known(.counterInc),
                 counterOp: TestFactories.counterOp(amount: 10),
             )
-            var pool = ObjectsPool(rootDelegate: MockLiveMapObjectPoolDelegate(), rootCoreSDK: MockCoreSDK(channelState: .attaching), logger: logger)
+            var pool = ObjectsPool(logger: logger)
 
             // Apply operation with serial "ts1" which is lexicographically less than existing "ts2" and thus will be applied per RTLO4a (this is a non-pathological case of RTOL4a, that spec point being fully tested elsewhere)
             counter.apply(
@@ -270,7 +281,7 @@ struct DefaultLiveCounterTests {
 
             // Check that the COUNTER_INC side-effects didn't happen:
             // Verify the operation was discarded - data unchanged (should still be 5 from creation)
-            #expect(try counter.value == 5)
+            #expect(try counter.value(coreSDK: coreSDK) == 5)
             // Verify site timeserials unchanged
             #expect(counter.testsOnly_siteTimeserials == ["site1": "ts2"])
         }
@@ -280,10 +291,11 @@ struct DefaultLiveCounterTests {
         @Test
         func appliesCounterCreateOperation() throws {
             let logger = TestLogger()
-            let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attaching), logger: logger)
+            let counter = InternalDefaultLiveCounter.createZeroValued(objectID: "arbitrary", logger: logger)
+            let coreSDK = MockCoreSDK(channelState: .attaching)
 
             let operation = TestFactories.counterCreateOperation(count: 15)
-            var pool = ObjectsPool(rootDelegate: MockLiveMapObjectPoolDelegate(), rootCoreSDK: MockCoreSDK(channelState: .attaching), logger: logger)
+            var pool = ObjectsPool(logger: logger)
 
             // Apply COUNTER_CREATE operation
             counter.apply(
@@ -294,7 +306,7 @@ struct DefaultLiveCounterTests {
             )
 
             // Verify the operation was applied - initial value merged (the full logic of RTLC8 is tested elsewhere; we just check for some of its side effects here)
-            #expect(try counter.value == 15)
+            #expect(try counter.value(coreSDK: coreSDK) == 15)
             #expect(counter.testsOnly_createOperationIsMerged)
             // Verify RTLC7c side-effect: site timeserial was updated
             #expect(counter.testsOnly_siteTimeserials == ["site1": "ts1"])
@@ -305,17 +317,18 @@ struct DefaultLiveCounterTests {
         @Test
         func appliesCounterIncOperation() throws {
             let logger = TestLogger()
-            let counter = DefaultLiveCounter.createZeroValued(objectID: "arbitrary", coreSDK: MockCoreSDK(channelState: .attaching), logger: logger)
+            let counter = InternalDefaultLiveCounter.createZeroValued(objectID: "arbitrary", logger: logger)
+            let coreSDK = MockCoreSDK(channelState: .attaching)
 
             // Set initial data
             counter.replaceData(using: TestFactories.counterObjectState(siteTimeserials: [:], count: 5))
-            #expect(try counter.value == 5)
+            #expect(try counter.value(coreSDK: coreSDK) == 5)
 
             let operation = TestFactories.objectOperation(
                 action: .known(.counterInc),
                 counterOp: TestFactories.counterOp(amount: 10),
             )
-            var pool = ObjectsPool(rootDelegate: MockLiveMapObjectPoolDelegate(), rootCoreSDK: MockCoreSDK(channelState: .attaching), logger: logger)
+            var pool = ObjectsPool(logger: logger)
 
             // Apply COUNTER_INC operation
             counter.apply(
@@ -326,7 +339,7 @@ struct DefaultLiveCounterTests {
             )
 
             // Verify the operation was applied - amount added to data (the full logic of RTLC9 is tested elsewhere; we just check for some of its side effects here)
-            #expect(try counter.value == 15) // 5 + 10
+            #expect(try counter.value(coreSDK: coreSDK) == 15) // 5 + 10
             // Verify RTLC7c side-effect: site timeserial was updated
             #expect(counter.testsOnly_siteTimeserials == ["site1": "ts1"])
         }

--- a/Tests/AblyLiveObjectsTests/JS Integration Tests/ObjectsIntegrationTests.swift
+++ b/Tests/AblyLiveObjectsTests/JS Integration Tests/ObjectsIntegrationTests.swift
@@ -299,9 +299,6 @@ private struct ObjectsIntegrationTests {
                         for key in valueMapKeys {
                             #expect(try valuesMap.get(key: key) != nil, "Check value at key=\"\(key)\" in nested map exists")
                         }
-
-                        // TODO: remove (Swift-only) — keep channel alive until we've executed our test case. We'll address this in https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/9
-                        withExtendedLifetime(channel) {}
                     },
                 ),
                 .init(
@@ -371,9 +368,6 @@ private struct ObjectsIntegrationTests {
                             #expect(try #require(map2.get(key: "shouldStay")?.stringValue) == "foo", "Check map has correct value for \"shouldStay\" key")
                             #expect(try #require(map2.get(key: "anotherKey")?.stringValue) == "baz", "Check map has correct value for \"anotherKey\" key")
                             #expect(try map2.get(key: "shouldDelete") == nil, "Check map does not have \"shouldDelete\" key")
-
-                            // TODO: remove (Swift-only) — keep channel alive until we've executed our test case. We'll address this in https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/9
-                            withExtendedLifetime(channel2) {}
                         }
                     },
                 ),
@@ -447,9 +441,6 @@ private struct ObjectsIntegrationTests {
                             let counterObj = try #require(root.get(key: counter.key)?.liveCounterValue)
                             #expect(try counterObj.value == Double(counter.value), "Check counter at key=\"\(counter.key)\" in root has correct value")
                         }
-
-                        // TODO: remove (Swift-only) — keep channel alive until we've executed our test case. We'll address this in https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/9
-                        withExtendedLifetime(channel) {}
                     },
                 ),
                 .init(
@@ -490,9 +481,6 @@ private struct ObjectsIntegrationTests {
 
                         let mapFromValuesMap = try #require(valuesMap.get(key: "mapKey")?.liveMapValue)
                         #expect(try mapFromValuesMap.size == 1, "Check nested map has correct number of keys")
-
-                        // TODO: remove (Swift-only) — keep channel alive until we've executed our test case. We'll address this in https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/9
-                        withExtendedLifetime(channel) {}
                     },
                 ),
                 .init(
@@ -521,9 +509,6 @@ private struct ObjectsIntegrationTests {
                         let mapFromValuesMap = try #require(valuesMap.get(key: "mapKey")?.liveMapValue, "Check nested map is of type LiveMap")
                         #expect(try mapFromValuesMap.size == 1, "Check nested map has correct number of keys")
                         #expect(mapFromValuesMap === referencedMap, "Check nested map is the same object instance as map on the root")
-
-                        // TODO: remove (Swift-only) — keep channel alive until we've executed our test case. We'll address this in https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/9
-                        withExtendedLifetime(channel) {}
                     },
                 ),
                 .init(
@@ -751,9 +736,6 @@ private struct ObjectsIntegrationTests {
                     clientOptions: testCase.options,
                 ),
             )
-
-            // TODO: remove (Swift-only) — keep channel alive until we've executed our test case. We'll address this in https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/9
-            withExtendedLifetime(channel) {}
         }
     }
 

--- a/Tests/AblyLiveObjectsTests/JS Integration Tests/ObjectsIntegrationTests.swift
+++ b/Tests/AblyLiveObjectsTests/JS Integration Tests/ObjectsIntegrationTests.swift
@@ -9,29 +9,12 @@ import Testing
 
 // MARK: - Top-level helpers
 
-private func realtimeWithObjects(options: PartialClientOptions = .init()) async throws -> ARTRealtime {
-    let key = try await Sandbox.fetchSharedAPIKey()
-    let clientOptions = ARTClientOptions(key: key)
-    clientOptions.plugins = [.liveObjects: AblyLiveObjects.Plugin.self]
-    clientOptions.environment = "sandbox"
-
-    clientOptions.testOptions.transportFactory = TestProxyTransportFactory()
-
-    if TestLogger.loggingEnabled {
-        clientOptions.logLevel = .verbose
-    }
-
-    if let useBinaryProtocol = options.useBinaryProtocol {
-        clientOptions.useBinaryProtocol = useBinaryProtocol
-    }
-
-    return ARTRealtime(options: clientOptions)
+private func realtimeWithObjects(options: ClientHelper.PartialClientOptions) async throws -> ARTRealtime {
+    try await ClientHelper.realtimeWithObjects(options: options)
 }
 
 private func channelOptionsWithObjects() -> ARTRealtimeChannelOptions {
-    let options = ARTRealtimeChannelOptions()
-    options.modes = [.objectSubscribe, .objectPublish]
-    return options
+    ClientHelper.channelOptionsWithObjects()
 }
 
 // Swift version of the JS lexicoTimeserial function
@@ -152,7 +135,7 @@ private let objectsFixturesChannel = "objects_fixtures"
 private struct TestCase<Context>: Identifiable, CustomStringConvertible {
     var disabled: Bool
     var scenario: TestScenario<Context>
-    var options: PartialClientOptions
+    var options: ClientHelper.PartialClientOptions
     var channelName: String
 
     /// This `Identifiable` conformance allows us to re-run individual test cases from the Xcode UI (https://developer.apple.com/documentation/testing/parameterizedtesting#Run-selected-test-cases)
@@ -175,11 +158,7 @@ private struct TestCase<Context>: Identifiable, CustomStringConvertible {
 /// Enables `TestCase`'s conformance to `Identifiable`.
 private struct TestCaseID: Encodable, Hashable {
     var description: String
-    var options: PartialClientOptions?
-}
-
-private struct PartialClientOptions: Encodable, Hashable {
-    var useBinaryProtocol: Bool?
+    var options: ClientHelper.PartialClientOptions?
 }
 
 /// The input to `forScenarios`.
@@ -268,7 +247,7 @@ private struct ObjectsIntegrationTests {
             var channelName: String
             var channel: ARTRealtimeChannel
             var client: ARTRealtime
-            var clientOptions: PartialClientOptions
+            var clientOptions: ClientHelper.PartialClientOptions
         }
 
         static let scenarios: [TestScenario<Context>] = {

--- a/Tests/AblyLiveObjectsTests/ObjectLifetimesTests.swift
+++ b/Tests/AblyLiveObjectsTests/ObjectLifetimesTests.swift
@@ -1,0 +1,237 @@
+import Ably.Private
+@testable import AblyLiveObjects
+import Testing
+
+struct ObjectLifetimesTests {
+    @Test("LiveObjects functionality works with only a strong reference to channel's public objects property")
+    func withStrongReferenceToPublicObjectsProperty() async throws {
+        // The objects that we'll create.
+        struct CreatedObjects {
+            /// The queue on which we expect ably-cocoa's QueuedDealloc mechanism to enqueue the relinquishing of `weakInternalRealtime`.
+            var realtimeDeallocQueue: DispatchQueue
+
+            weak var weakPublicRealtime: ARTRealtime?
+            weak var weakInternalRealtime: ARTRealtimeInternal?
+            weak var weakPublicChannel: ARTRealtimeChannel?
+            weak var weakInternalChannel: ARTRealtimeChannelInternal?
+            var strongPublicRealtimeObjects: PublicDefaultRealtimeObjects
+            weak var weakInternalRealtimeObjects: InternalDefaultRealtimeObjects?
+        }
+
+        // What we're left with after discarding a CreatedObjects.
+        struct RemainingObjects {
+            /// The queue on which we expect ably-cocoa's QueuedDealloc mechanism to enqueue the relinquishing of `weakInternalRealtime`.
+            var realtimeDeallocQueue: DispatchQueue
+
+            // weakPublicRealtime is gone now
+            weak var weakInternalRealtime: ARTRealtimeInternal?
+            // weakPublicChannel is gone now
+            weak var weakInternalChannel: ARTRealtimeChannelInternal?
+            weak var weakPublicRealtimeObjects: PublicDefaultRealtimeObjects?
+            weak var weakInternalRealtimeObjects: InternalDefaultRealtimeObjects?
+        }
+
+        func createAndDiscardObjects() async throws -> RemainingObjects {
+            func createObjects() async throws -> CreatedObjects {
+                // We disable autoConnect since being connected extends the internal Realtime instance's lifetime (it stays alive whilst connected), and I don't want that interfering with this test.
+                let realtime = try await ClientHelper.realtimeWithObjects(options: .init(autoConnect: false))
+                let channel = realtime.channels.get(UUID().uuidString, options: ClientHelper.channelOptionsWithObjects())
+                let anyObjects = channel.objects
+                // For some reason putting `channel.objects as? PublicDefaultRealtimeObjects` inside the #require gives "no calls to throwing functions occur within 'try' expression" 🤷
+                let objects = try #require(anyObjects as? PublicDefaultRealtimeObjects)
+
+                return .init(
+                    realtimeDeallocQueue: realtime.internal.queue,
+                    weakPublicRealtime: realtime,
+                    weakInternalRealtime: realtime.internal,
+                    weakPublicChannel: channel,
+                    weakInternalChannel: channel.internal,
+                    strongPublicRealtimeObjects: objects,
+                    weakInternalRealtimeObjects: objects.testsOnly_proxied,
+                )
+            }
+
+            let createdObjects = try await createObjects()
+
+            // The only public object we have a strong reference to is strongPublicRealtimeObjects, so the other public objects should have already been deallocated
+            #expect(createdObjects.weakPublicRealtime == nil)
+            #expect(createdObjects.weakPublicChannel == nil)
+
+            // Now we check that, since we still have a strong reference to strongPublicRealtimeObjects, none of the dependencies that it needs in order to function have been deallocated.
+            await withCheckedContinuation { continuation in
+                // We wait for everything on realtimeDeallocQueue to execute, to be sure that we'd catch a dealloc that had been enqueued via ably-cocoa's QueuedDealloc mechanism.
+                createdObjects.realtimeDeallocQueue.async {
+                    continuation.resume()
+                }
+            }
+            #expect(createdObjects.weakInternalRealtime != nil)
+            #expect(createdObjects.weakInternalChannel != nil)
+            #expect(createdObjects.weakInternalRealtimeObjects != nil)
+
+            // TODO: test that we can receive events on a LiveObject (https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/30)
+
+            // Note that after this return we no longer have a reference to createdObjects and thus no longer have a strong reference to our public RealtimeObjects instance
+            return .init(
+                realtimeDeallocQueue: createdObjects.realtimeDeallocQueue,
+                weakInternalRealtime: createdObjects.weakInternalRealtime,
+                weakInternalChannel: createdObjects.weakInternalChannel,
+                weakPublicRealtimeObjects: createdObjects.strongPublicRealtimeObjects,
+                weakInternalRealtimeObjects: createdObjects.weakInternalRealtimeObjects,
+            )
+        }
+
+        let remainingObjects = try await createAndDiscardObjects()
+
+        // Check that the public RealtimeObjects has been deallocated now that we've no longer got a strong reference to it
+        #expect(remainingObjects.weakPublicRealtimeObjects == nil)
+
+        // Check that the internal objects that the public RealtimeObjects needed in order to function have now been deallocated
+        await withCheckedContinuation { continuation in
+            // We wait for everything on realtimeDeallocQueue to execute, to be sure that we'd catch a dealloc that had been enqueued via ably-cocoa's QueuedDealloc mechanism.
+            remainingObjects.realtimeDeallocQueue.async {
+                continuation.resume()
+            }
+        }
+
+        #expect(remainingObjects.weakInternalRealtime == nil)
+        #expect(remainingObjects.weakInternalChannel == nil)
+        #expect(remainingObjects.weakInternalRealtimeObjects == nil)
+    }
+
+    @Test("LiveObjects functionality works with only a strong reference to a public LiveObject")
+    func withStrongReferenceToPublicLiveObject() async throws {
+        // Note: This test is very similar to withStrongReferenceToPublicObjectsProperty but "one layer down" — i.e. it checks that instead of a RealtimeObjects reference keeping everything working, a LiveObject reference keeps everything working. Keep these two tests in sync.
+
+        // The objects that we'll create.
+        struct CreatedObjects {
+            /// The queue on which we expect ably-cocoa's QueuedDealloc mechanism to enqueue the relinquishing of `weakInternalRealtime`.
+            var realtimeDeallocQueue: DispatchQueue
+
+            weak var weakPublicRealtime: ARTRealtime?
+            weak var weakInternalRealtime: ARTRealtimeInternal?
+            weak var weakPublicChannel: ARTRealtimeChannel?
+            weak var weakInternalChannel: ARTRealtimeChannelInternal?
+            weak var weakPublicRealtimeObjects: PublicDefaultRealtimeObjects?
+            weak var weakInternalRealtimeObjects: InternalDefaultRealtimeObjects?
+            var strongPublicLiveObject: PublicDefaultLiveMap
+            weak var weakInternalLiveObject: InternalDefaultLiveMap?
+        }
+
+        // What we're left with after discarding a CreatedObjects.
+        struct RemainingObjects {
+            /// The queue on which we expect ably-cocoa's QueuedDealloc mechanism to enqueue the relinquishing of `weakInternalRealtime`.
+            var realtimeDeallocQueue: DispatchQueue
+
+            // weakPublicRealtime is gone now
+            weak var weakInternalRealtime: ARTRealtimeInternal?
+            // weakPublicChannel is gone now
+            weak var weakInternalChannel: ARTRealtimeChannelInternal?
+            // weakPublicRealtimeObjects is gone now
+            weak var weakInternalRealtimeObjects: InternalDefaultRealtimeObjects?
+            weak var weakPublicLiveObject: PublicDefaultLiveMap?
+            weak var weakInternalLiveObject: InternalDefaultLiveMap?
+        }
+
+        func createAndDiscardObjects() async throws -> RemainingObjects {
+            func createObjects() async throws -> CreatedObjects {
+                // We disable autoConnect since being connected extends the internal Realtime instance's lifetime (it stays alive whilst connected), and I don't want that interfering with this test.
+                let realtime = try await ClientHelper.realtimeWithObjects()
+                // Unlike in withStrongReferenceToPublicObjectsProperty, we'll have to allow it to connect, because we need to attach so that getRoot() returns. We'll instead manually close the connection before proceeding with the test
+                let channel = realtime.channels.get(UUID().uuidString, options: ClientHelper.channelOptionsWithObjects())
+                try await channel.attachAsync()
+                let anyObjects = channel.objects
+                // For some reason putting `channel.objects as? PublicDefaultRealtimeObjects` inside the #require gives "no calls to throwing functions occur within 'try' expression" 🤷
+                let objects = try #require(anyObjects as? PublicDefaultRealtimeObjects)
+                let root = try #require(try await anyObjects.getRoot() as? PublicDefaultLiveMap)
+
+                // Wait for the connection to close, as mentioned above
+                async let connectionClosedPromise: Void = withCheckedContinuation { continuation in
+                    realtime.connection.on(.closed) { _ in
+                        continuation.resume()
+                    }
+                }
+                realtime.connection.close()
+                _ = await connectionClosedPromise
+
+                return .init(
+                    realtimeDeallocQueue: realtime.internal.queue,
+                    weakPublicRealtime: realtime,
+                    weakInternalRealtime: realtime.internal,
+                    weakPublicChannel: channel,
+                    weakInternalChannel: channel.internal,
+                    weakPublicRealtimeObjects: objects,
+                    weakInternalRealtimeObjects: objects.testsOnly_proxied,
+                    strongPublicLiveObject: root,
+                    weakInternalLiveObject: root.testsOnly_proxied,
+                )
+            }
+
+            let createdObjects = try await createObjects()
+
+            // The only public object we have a strong reference to is strongPublicLiveObject, so the other public objects should have already been deallocated
+            #expect(createdObjects.weakPublicRealtime == nil)
+            #expect(createdObjects.weakPublicChannel == nil)
+            #expect(createdObjects.weakPublicRealtimeObjects == nil)
+
+            // Now we check that, since we still have a strong reference to strongPublicLiveObject, none of the dependencies that it needs in order to function have been deallocated.
+            await withCheckedContinuation { continuation in
+                // We wait for everything on realtimeDeallocQueue to execute, to be sure that we'd catch a dealloc that had been enqueued via ably-cocoa's QueuedDealloc mechanism.
+                createdObjects.realtimeDeallocQueue.async {
+                    continuation.resume()
+                }
+            }
+            #expect(createdObjects.weakInternalRealtime != nil)
+            #expect(createdObjects.weakInternalChannel != nil)
+            #expect(createdObjects.weakInternalRealtimeObjects != nil)
+            #expect(createdObjects.weakInternalLiveObject != nil)
+
+            // TODO: test that we can receive events on a LiveObject (https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/30)
+
+            // Note that after this return we no longer have a reference to createdObjects and thus no longer have a strong reference to our public LiveObject instance
+            return .init(
+                realtimeDeallocQueue: createdObjects.realtimeDeallocQueue,
+                weakInternalRealtime: createdObjects.weakInternalRealtime,
+                weakInternalChannel: createdObjects.weakInternalChannel,
+                weakInternalRealtimeObjects: createdObjects.weakInternalRealtimeObjects,
+                weakPublicLiveObject: createdObjects.strongPublicLiveObject,
+                weakInternalLiveObject: createdObjects.weakInternalLiveObject,
+            )
+        }
+
+        let remainingObjects = try await createAndDiscardObjects()
+
+        // Check that the public LiveObject has been deallocated now that we've no longer got a strong reference to it
+        #expect(remainingObjects.weakPublicLiveObject == nil)
+
+        // Check that the internal objects that the public LiveObject needed in order to function have now been deallocated
+        await withCheckedContinuation { continuation in
+            // We wait for everything on realtimeDeallocQueue to execute, to be sure that we'd catch a dealloc that had been enqueued via ably-cocoa's QueuedDealloc mechanism.
+            remainingObjects.realtimeDeallocQueue.async {
+                continuation.resume()
+            }
+        }
+
+        #expect(remainingObjects.weakInternalRealtime == nil)
+        #expect(remainingObjects.weakInternalChannel == nil)
+        #expect(remainingObjects.weakInternalRealtimeObjects == nil)
+        #expect(remainingObjects.weakInternalLiveObject == nil)
+    }
+
+    @Test("Public objects have a stable identity")
+    func publicObjectIdentity() async throws {
+        let realtime = try await ClientHelper.realtimeWithObjects()
+        defer { realtime.close() }
+        let channel = realtime.channels.get(UUID().uuidString, options: ClientHelper.channelOptionsWithObjects())
+        try await channel.attachAsync()
+
+        let objects = try #require(channel.objects as? PublicDefaultRealtimeObjects)
+        let root = try #require(try await objects.getRoot() as? PublicDefaultLiveMap)
+
+        let objectsAgain = try #require(channel.objects as? PublicDefaultRealtimeObjects)
+        let rootAgain = try #require(try await objectsAgain.getRoot() as? PublicDefaultLiveMap)
+
+        #expect(objects as AnyObject === objectsAgain as AnyObject)
+        #expect(root === rootAgain)
+        // TODO: when we have an easy way of populating the ObjectsPool (i.e. once we have a write API) then also test with a non-root LiveMap and a counter (https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/30)
+    }
+}


### PR DESCRIPTION
**Note: This PR is based on top of #25; please review that one first.**

We adopt a pattern whereby the LiveObjects SDK functions correctly as long as the user is holding a reference to any object vended by the public API of the SDK. We do this by copying the ably-cocoa approach of having separate public and internal versions of objects.

See commit messages for more details.

Resolves #9.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced public-facing wrapper classes for LiveObjects, LiveMap, and LiveCounter, ensuring stable identity and improved memory management.
  * Added a centralized store to manage and cache public proxy objects for internal live objects.
  * Enhanced conversion between internal and public live map values.
  * Added new helper utilities for integration testing.

* **Bug Fixes**
  * Improved lifecycle and memory management for LiveObjects, ensuring correct deallocation and stable references.

* **Documentation**
  * Updated contributing guidelines with a detailed section on memory management and object lifetimes.

* **Refactor**
  * Renamed and restructured internal classes and methods for clarity and separation between internal and public APIs.
  * Simplified method signatures by removing unnecessary dependencies and updating parameter passing.

* **Tests**
  * Added and updated test suites to verify memory management, object lifetimes, and new public APIs.
  * Refactored test helpers and test cases to align with the new architecture and naming conventions.

* **Chores**
  * Updated dependencies and package configurations for test targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->