### PR TITLE
[ECO-5461] Implement tombstoning and garbage collection spec

### DIFF
--- a/Sources/AblyLiveObjects/Internal/InternalDefaultLiveCounter.swift
+++ b/Sources/AblyLiveObjects/Internal/InternalDefaultLiveCounter.swift
@@ -225,6 +225,11 @@ internal final class InternalDefaultLiveCounter: Sendable {
             // RTLC6a: Replace the private siteTimeserials with the value from ObjectState.siteTimeserials
             liveObjectMutableState.siteTimeserials = state.siteTimeserials
 
+            // RTLC6e, RTLC6e1: No-op if we're already tombstone
+            if liveObjectMutableState.isTombstone {
+                return .noop
+            }
+
             // RTLC6b: Set the private flag createOperationIsMerged to false
             liveObjectMutableState.createOperationIsMerged = false
 

--- a/Sources/AblyLiveObjects/Internal/InternalDefaultLiveCounter.swift
+++ b/Sources/AblyLiveObjects/Internal/InternalDefaultLiveCounter.swift
@@ -279,6 +279,12 @@ internal final class InternalDefaultLiveCounter: Sendable {
             // RTLC7c
             liveObjectMutableState.siteTimeserials[applicableOperation.objectMessageSiteCode] = applicableOperation.objectMessageSerial
 
+            // RTLC7e
+            // TODO: are we still meant to update siteTimeserials? https://github.com/ably/specification/pull/350/files#r2218718854
+            if liveObjectMutableState.isTombstone {
+                return
+            }
+
             switch operation.action {
             case .known(.counterCreate):
                 // RTLC7d1

--- a/Sources/AblyLiveObjects/Internal/InternalDefaultLiveCounter.swift
+++ b/Sources/AblyLiveObjects/Internal/InternalDefaultLiveCounter.swift
@@ -317,5 +317,11 @@ internal final class InternalDefaultLiveCounter: Sendable {
             data += amount
             return .update(DefaultLiveCounterUpdate(amount: amount))
         }
+
+        /// Needed for ``InternalLiveObject`` conformance.
+        mutating func resetDataToZeroValued() {
+            // RTLC4
+            data = 0
+        }
     }
 }

--- a/Sources/AblyLiveObjects/Internal/InternalDefaultLiveCounter.swift
+++ b/Sources/AblyLiveObjects/Internal/InternalDefaultLiveCounter.swift
@@ -211,6 +211,13 @@ internal final class InternalDefaultLiveCounter: Sendable {
         }
     }
 
+    /// Returns the object's RTLO3e `tombstonedAt` property.
+    internal var tombstonedAt: Date? {
+        mutex.withLock {
+            mutableState.liveObjectMutableState.tombstonedAt
+        }
+    }
+
     // MARK: - Mutable state and the operations that affect it
 
     private struct MutableState: InternalLiveObject {

--- a/Sources/AblyLiveObjects/Internal/InternalDefaultLiveCounter.swift
+++ b/Sources/AblyLiveObjects/Internal/InternalDefaultLiveCounter.swift
@@ -196,6 +196,15 @@ internal final class InternalDefaultLiveCounter: Sendable {
         }
     }
 
+    // MARK: - LiveObject
+
+    /// Returns the object's RTLO3d `isTombstone` property.
+    internal var isTombstone: Bool {
+        mutex.withLock {
+            mutableState.liveObjectMutableState.isTombstone
+        }
+    }
+
     // MARK: - Mutable state and the operations that affect it
 
     private struct MutableState: InternalLiveObject {

--- a/Sources/AblyLiveObjects/Internal/InternalDefaultLiveMap.swift
+++ b/Sources/AblyLiveObjects/Internal/InternalDefaultLiveMap.swift
@@ -470,6 +470,12 @@ internal final class InternalDefaultLiveMap: Sendable {
             // RTLM15c
             liveObjectMutableState.siteTimeserials[applicableOperation.objectMessageSiteCode] = applicableOperation.objectMessageSerial
 
+            // RTLM15e
+            // TODO: are we still meant to update siteTimeserials? https://github.com/ably/specification/pull/350/files#r2218718854
+            if liveObjectMutableState.isTombstone {
+                return
+            }
+
             switch operation.action {
             case .known(.mapCreate):
                 // RTLM15d1

--- a/Sources/AblyLiveObjects/Internal/InternalDefaultLiveMap.swift
+++ b/Sources/AblyLiveObjects/Internal/InternalDefaultLiveMap.swift
@@ -541,6 +541,18 @@ internal final class InternalDefaultLiveMap: Sendable {
                 )
                 // RTLM15d3a
                 liveObjectMutableState.emit(update, on: userCallbackQueue)
+            case .known(.objectDelete):
+                let dataBeforeApplyingOperation = data
+
+                // RTLM15d5
+                applyObjectDeleteOperation(
+                    objectMessageSerialTimestamp: objectMessageSerialTimestamp,
+                    logger: logger,
+                    clock: clock,
+                )
+
+                // RTLM15d5a
+                liveObjectMutableState.emit(.update(.init(update: dataBeforeApplyingOperation.mapValues { _ in .removed })), on: userCallbackQueue)
             default:
                 // RTLM15d4
                 logger.log("Operation \(operation) has unsupported action for LiveMap; discarding", level: .warn)

--- a/Sources/AblyLiveObjects/Internal/InternalDefaultLiveMap.swift
+++ b/Sources/AblyLiveObjects/Internal/InternalDefaultLiveMap.swift
@@ -373,6 +373,11 @@ internal final class InternalDefaultLiveMap: Sendable {
             // RTLM6a: Replace the private siteTimeserials with the value from ObjectState.siteTimeserials
             liveObjectMutableState.siteTimeserials = state.siteTimeserials
 
+            // RTLM6e, RTLM6e1: No-op if we're already tombstone
+            if liveObjectMutableState.isTombstone {
+                return .noop
+            }
+
             // RTLM6b: Set the private flag createOperationIsMerged to false
             liveObjectMutableState.createOperationIsMerged = false
 

--- a/Sources/AblyLiveObjects/Internal/InternalDefaultLiveMap.swift
+++ b/Sources/AblyLiveObjects/Internal/InternalDefaultLiveMap.swift
@@ -378,6 +378,20 @@ internal final class InternalDefaultLiveMap: Sendable {
                 return .noop
             }
 
+            // RTLM6f: Tombstone if state indicates tombstoned
+            if state.tombstone {
+                let dataBeforeTombstoning = data
+
+                tombstone(
+                    objectMessageSerialTimestamp: objectMessageSerialTimestamp,
+                    logger: logger,
+                    clock: clock,
+                )
+
+                // RTLM6f1
+                return .update(.init(update: dataBeforeTombstoning.mapValues { _ in .removed }))
+            }
+
             // RTLM6b: Set the private flag createOperationIsMerged to false
             liveObjectMutableState.createOperationIsMerged = false
 

--- a/Sources/AblyLiveObjects/Internal/InternalDefaultLiveMap.swift
+++ b/Sources/AblyLiveObjects/Internal/InternalDefaultLiveMap.swift
@@ -655,6 +655,12 @@ internal final class InternalDefaultLiveMap: Sendable {
             let mapUpdate = DefaultLiveMapUpdate(update: previousData.mapValues { _ in .removed })
             liveObjectMutableState.emit(.update(mapUpdate), on: userCallbackQueue)
         }
+
+        /// Needed for ``InternalLiveObject`` conformance.
+        mutating func resetDataToZeroValued() {
+            // RTLM4
+            data = [:]
+        }
     }
 
     // MARK: - Helper Methods

--- a/Sources/AblyLiveObjects/Internal/InternalLiveObject.swift
+++ b/Sources/AblyLiveObjects/Internal/InternalLiveObject.swift
@@ -1,3 +1,5 @@
+internal import AblyPlugin
+
 /// Provides RTLO spec point functionality common to all LiveObjects.
 ///
 /// This exists in addition to ``LiveObjectMutableState`` to enable polymorphism.
@@ -5,4 +7,44 @@ internal protocol InternalLiveObject<Update> {
     associatedtype Update: Sendable
 
     var liveObjectMutableState: LiveObjectMutableState<Update> { get set }
+
+    /// Resets the LiveObject's internal data to that of a zero-value, per RTLO4e4.
+    mutating func resetDataToZeroValued()
+}
+
+internal extension InternalLiveObject {
+    /// Convenience method for tombstoning a `LiveObject`, as specified in RTLO4e.
+    mutating func tombstone(
+        objectMessageSerialTimestamp: Date?,
+        logger: Logger,
+        clock: SimpleClock,
+    ) {
+        // RTLO4e2, RTLO4e3
+        if let objectMessageSerialTimestamp {
+            // RTLO4e3a
+            liveObjectMutableState.tombstonedAt = objectMessageSerialTimestamp
+        } else {
+            // RTLO4e3b1
+            logger.log("serialTimestamp not found in ObjectMessage, using local clock for tombstone timestamp", level: .debug)
+            // RTLO4e3b
+            liveObjectMutableState.tombstonedAt = clock.now
+        }
+
+        // RTLO4e4
+        resetDataToZeroValued()
+    }
+
+    /// Applies an `OBJECT_DELETE` operation, per RTLO5.
+    mutating func applyObjectDeleteOperation(
+        objectMessageSerialTimestamp: Date?,
+        logger: Logger,
+        clock: SimpleClock,
+    ) {
+        // RTLO5b
+        tombstone(
+            objectMessageSerialTimestamp: objectMessageSerialTimestamp,
+            logger: logger,
+            clock: clock,
+        )
+    }
 }

--- a/Sources/AblyLiveObjects/Internal/InternalObjectsMapEntry.swift
+++ b/Sources/AblyLiveObjects/Internal/InternalObjectsMapEntry.swift
@@ -1,13 +1,20 @@
-/// The entries stored in a `LiveMap`'s data. Same as an `ObjectsMapEntry` but with an additional `tombstonedAt` property, per RTLM3a. (This property will be added in an upcoming commit.)
+import Foundation
+
+/// The entries stored in a `LiveMap`'s data. Same as an `ObjectsMapEntry` but with an additional `tombstonedAt` property, per RTLM3a.
 internal struct InternalObjectsMapEntry {
-    internal var tombstone: Bool? // OME2a
+    internal var tombstonedAt: Date? // RTLM3a
+    internal var tombstone: Bool {
+        // TODO: Confirm that we don't need to store this (https://github.com/ably/specification/pull/350/files#r2213895661)
+        tombstonedAt != nil
+    }
+
     internal var timeserial: String? // OME2b
     internal var data: ObjectData // OME2c
 }
 
 internal extension InternalObjectsMapEntry {
-    init(objectsMapEntry: ObjectsMapEntry) {
-        tombstone = objectsMapEntry.tombstone
+    init(objectsMapEntry: ObjectsMapEntry, tombstonedAt: Date?) {
+        self.tombstonedAt = tombstonedAt
         timeserial = objectsMapEntry.timeserial
         data = objectsMapEntry.data
     }

--- a/Sources/AblyLiveObjects/Internal/LiveObjectMutableState.swift
+++ b/Sources/AblyLiveObjects/Internal/LiveObjectMutableState.swift
@@ -10,6 +10,14 @@ internal struct LiveObjectMutableState<Update: Sendable> {
     internal var siteTimeserials: [String: String] = [:]
     // RTLO3c
     internal var createOperationIsMerged = false
+    // RTLO3d
+    internal var isTombstone: Bool {
+        // TODO: Confirm that we don't need to store this (https://github.com/ably/specification/pull/350/files#r2213895661)
+        tombstonedAt != nil
+    }
+
+    // RTLO3e
+    internal var tombstonedAt: Date?
 
     /// Internal bookkeeping for subscriptions.
     private var subscriptionsByID: [Subscription.ID: Subscription] = [:]
@@ -17,9 +25,11 @@ internal struct LiveObjectMutableState<Update: Sendable> {
     internal init(
         objectID: String,
         testsOnly_siteTimeserials siteTimeserials: [String: String]? = nil,
+        testsOnly_tombstonedAt tombstonedAt: Date? = nil,
     ) {
         self.objectID = objectID
         self.siteTimeserials = siteTimeserials ?? [:]
+        self.tombstonedAt = tombstonedAt
     }
 
     /// Represents parameters of an operation that `canApplyOperation` has decided can be applied to a `LiveObject`.

--- a/Sources/AblyLiveObjects/Internal/ObjectsPool.swift
+++ b/Sources/AblyLiveObjects/Internal/ObjectsPool.swift
@@ -104,6 +104,16 @@ internal struct ObjectsPool {
                 )
             }
         }
+
+        /// Returns the object's RTLO3d `isTombstone` property.
+        internal var isTombstone: Bool {
+            switch self {
+            case let .counter(counter):
+                counter.isTombstone
+            case let .map(map):
+                map.isTombstone
+            }
+        }
     }
 
     /// Keyed by `objectId`.

--- a/Sources/AblyLiveObjects/Internal/ObjectsPool.swift
+++ b/Sources/AblyLiveObjects/Internal/ObjectsPool.swift
@@ -114,6 +114,15 @@ internal struct ObjectsPool {
                 map.isTombstone
             }
         }
+
+        internal var tombstonedAt: Date? {
+            switch self {
+            case let .counter(counter):
+                counter.tombstonedAt
+            case let .map(map):
+                map.tombstonedAt
+            }
+        }
     }
 
     /// Keyed by `objectId`.
@@ -307,5 +316,33 @@ internal struct ObjectsPool {
         // RTO4b2
         // TODO: this one is unclear (are we meant to replace the root or just clear its data?) https://github.com/ably/specification/pull/333/files#r2183493458. I believe that the answer is that we should just clear its data but the spec point needs to be clearer, see https://github.com/ably/specification/pull/346/files#r2201434895.
         root.resetData()
+    }
+
+    /// Performs garbage collection of tombstoned objects and map entries, per RTO10c.
+    internal mutating func performGarbageCollection(gracePeriod: TimeInterval, clock: SimpleClock, logger: Logger) {
+        logger.log("Performing garbage collection, grace period \(gracePeriod)s", level: .debug)
+
+        let now = clock.now
+
+        entries = entries.filter { key, entry in
+            if case let .map(map) = entry {
+                // RTO10c1a
+                map.releaseTombstonedEntries(gracePeriod: gracePeriod, clock: clock)
+            }
+
+            // RTO10c1b
+            let shouldRelease = {
+                guard let tombstonedAt = entry.tombstonedAt else {
+                    return false
+                }
+
+                return now.timeIntervalSince(tombstonedAt) >= gracePeriod
+            }()
+
+            if shouldRelease {
+                logger.log("Releasing tombstoned entry \(entry) for key \(key)", level: .debug)
+            }
+            return !shouldRelease
+        }
     }
 }

--- a/Sources/AblyLiveObjects/Public/Public Proxy Objects/PublicDefaultLiveMap.swift
+++ b/Sources/AblyLiveObjects/Public/Public Proxy Objects/PublicDefaultLiveMap.swift
@@ -34,7 +34,7 @@ internal final class PublicDefaultLiveMap: LiveMap {
 
     internal var size: Int {
         get throws(ARTErrorInfo) {
-            try proxied.size(coreSDK: coreSDK)
+            try proxied.size(coreSDK: coreSDK, delegate: delegate)
         }
     }
 

--- a/Tests/AblyLiveObjectsTests/Helpers/TestFactories.swift
+++ b/Tests/AblyLiveObjectsTests/Helpers/TestFactories.swift
@@ -406,12 +406,12 @@ struct TestFactories {
     ///
     /// This should be kept in sync with ``mapEntry``.
     static func internalMapEntry(
-        tombstone: Bool? = false,
+        tombstonedAt: Date? = nil,
         timeserial: String? = "ts1",
         data: ObjectData,
     ) -> InternalObjectsMapEntry {
         InternalObjectsMapEntry(
-            tombstone: tombstone,
+            tombstonedAt: tombstonedAt,
             timeserial: timeserial,
             data: data,
         )
@@ -440,13 +440,13 @@ struct TestFactories {
     static func internalStringMapEntry(
         key: String = "testKey",
         value: String = "testValue",
-        tombstone: Bool? = false,
+        tombstonedAt: Date? = nil,
         timeserial: String? = "ts1",
     ) -> (key: String, entry: InternalObjectsMapEntry) {
         (
             key: key,
             entry: internalMapEntry(
-                tombstone: tombstone,
+                tombstonedAt: tombstonedAt,
                 timeserial: timeserial,
                 data: ObjectData(string: value),
             ),

--- a/Tests/AblyLiveObjectsTests/InternalDefaultLiveMapTests.swift
+++ b/Tests/AblyLiveObjectsTests/InternalDefaultLiveMapTests.swift
@@ -284,7 +284,7 @@ struct InternalDefaultLiveMapTests {
 
             // Define actions to test
             let actions: [(String, () throws -> Any)] = [
-                ("size", { try map.size(coreSDK: coreSDK) }),
+                ("size", { try map.size(coreSDK: coreSDK, delegate: delegate) }),
                 ("entries", { try map.entries(coreSDK: coreSDK, delegate: delegate) }),
                 ("keys", { try map.keys(coreSDK: coreSDK, delegate: delegate) }),
                 ("values", { try map.values(coreSDK: coreSDK, delegate: delegate) }),
@@ -330,7 +330,7 @@ struct InternalDefaultLiveMapTests {
             )
 
             // Test size - should only count non-tombstoned entries
-            let size = try map.size(coreSDK: coreSDK)
+            let size = try map.size(coreSDK: coreSDK, delegate: delegate)
             #expect(size == 1)
 
             // Test entries - should only return non-tombstoned entries
@@ -372,7 +372,7 @@ struct InternalDefaultLiveMapTests {
                 clock: MockSimpleClock(),
             )
 
-            let size = try map.size(coreSDK: coreSDK)
+            let size = try map.size(coreSDK: coreSDK, delegate: delegate)
             let entries = try map.entries(coreSDK: coreSDK, delegate: delegate)
             let keys = try map.keys(coreSDK: coreSDK, delegate: delegate)
             let values = try map.values(coreSDK: coreSDK, delegate: delegate)
@@ -422,7 +422,7 @@ struct InternalDefaultLiveMapTests {
                 clock: MockSimpleClock(),
             )
 
-            let size = try map.size(coreSDK: coreSDK)
+            let size = try map.size(coreSDK: coreSDK, delegate: delegate)
             let entries = try map.entries(coreSDK: coreSDK, delegate: delegate)
             let keys = try map.keys(coreSDK: coreSDK, delegate: delegate)
             let values = try map.values(coreSDK: coreSDK, delegate: delegate)

--- a/Tests/AblyLiveObjectsTests/InternalDefaultLiveMapTests.swift
+++ b/Tests/AblyLiveObjectsTests/InternalDefaultLiveMapTests.swift
@@ -39,7 +39,7 @@ struct InternalDefaultLiveMapTests {
         func returnsNilWhenEntryIsTombstoned() throws {
             let logger = TestLogger()
             let entry = TestFactories.internalMapEntry(
-                tombstone: true,
+                tombstonedAt: Date(),
                 data: ObjectData(boolean: true), // Value doesn't matter as it's tombstoned
             )
             let coreSDK = MockCoreSDK(channelState: .attaching)
@@ -317,12 +317,11 @@ struct InternalDefaultLiveMapTests {
             let delegate = MockLiveMapObjectPoolDelegate()
             let map = InternalDefaultLiveMap(
                 testsOnly_data: [
-                    // tombstone is nil, so not considered tombstoned
+                    // tombstonedAt is nil, so not considered tombstoned
                     "active1": TestFactories.internalMapEntry(data: ObjectData(string: "value1")),
-                    // tombstone is false, so not considered tombstoned[
-                    "active2": TestFactories.internalMapEntry(tombstone: false, data: ObjectData(string: "value2")),
-                    "tombstoned": TestFactories.internalMapEntry(tombstone: true, data: ObjectData(string: "tombstoned")),
-                    "tombstoned2": TestFactories.internalMapEntry(tombstone: true, data: ObjectData(string: "tombstoned2")),
+                    // tombstonedAt is false, so not considered tombstoned
+                    "tombstoned": TestFactories.internalMapEntry(tombstonedAt: Date(), data: ObjectData(string: "tombstoned")),
+                    "tombstoned2": TestFactories.internalMapEntry(tombstonedAt: Date(), data: ObjectData(string: "tombstoned2")),
                 ],
                 objectID: "arbitrary",
                 logger: logger,
@@ -332,24 +331,23 @@ struct InternalDefaultLiveMapTests {
 
             // Test size - should only count non-tombstoned entries
             let size = try map.size(coreSDK: coreSDK)
-            #expect(size == 2)
+            #expect(size == 1)
 
             // Test entries - should only return non-tombstoned entries
             let entries = try map.entries(coreSDK: coreSDK, delegate: delegate)
-            #expect(entries.count == 2)
-            #expect(Set(entries.map(\.key)) == ["active1", "active2"])
+            #expect(entries.count == 1)
+            #expect(Set(entries.map(\.key)) == ["active1"])
             #expect(entries.first { $0.key == "active1" }?.value.stringValue == "value1")
-            #expect(entries.first { $0.key == "active2" }?.value.stringValue == "value2")
 
             // Test keys - should only return keys from non-tombstoned entries
             let keys = try map.keys(coreSDK: coreSDK, delegate: delegate)
-            #expect(keys.count == 2)
-            #expect(Set(keys) == ["active1", "active2"])
+            #expect(keys.count == 1)
+            #expect(Set(keys) == ["active1"])
 
             // Test values - should only return values from non-tombstoned entries
             let values = try map.values(coreSDK: coreSDK, delegate: delegate)
-            #expect(values.count == 2)
-            #expect(Set(values.compactMap(\.stringValue)) == Set(["value1", "value2"]))
+            #expect(values.count == 1)
+            #expect(Set(values.compactMap(\.stringValue)) == Set(["value1"]))
         }
 
         // MARK: - Consistency Tests
@@ -507,7 +505,7 @@ struct InternalDefaultLiveMapTests {
                 let delegate = MockLiveMapObjectPoolDelegate()
                 let coreSDK = MockCoreSDK(channelState: .attaching)
                 let map = InternalDefaultLiveMap(
-                    testsOnly_data: ["key1": TestFactories.internalMapEntry(tombstone: true, timeserial: "ts1", data: ObjectData(string: "existing"))],
+                    testsOnly_data: ["key1": TestFactories.internalMapEntry(tombstonedAt: Date(), timeserial: "ts1", data: ObjectData(string: "existing"))],
                     objectID: "arbitrary",
                     logger: logger,
                     userCallbackQueue: .main,
@@ -687,7 +685,7 @@ struct InternalDefaultLiveMapTests {
                 )
 
                 // Try to apply operation with lower timeserial (ts1 < ts2), cannot be applied per RTLM9
-                let update = map.testsOnly_applyMapRemoveOperation(key: "key1", operationTimeserial: "ts1")
+                let update = map.testsOnly_applyMapRemoveOperation(key: "key1", operationTimeserial: "ts1", operationSerialTimestamp: nil)
 
                 // Verify the operation was discarded - existing data unchanged
                 #expect(try map.get(key: "key1", coreSDK: coreSDK, delegate: delegate)?.stringValue == "existing")
@@ -705,7 +703,7 @@ struct InternalDefaultLiveMapTests {
                 let delegate = MockLiveMapObjectPoolDelegate()
                 let coreSDK = MockCoreSDK(channelState: .attaching)
                 let map = InternalDefaultLiveMap(
-                    testsOnly_data: ["key1": TestFactories.internalMapEntry(tombstone: false, timeserial: "ts1", data: ObjectData(string: "existing"))],
+                    testsOnly_data: ["key1": TestFactories.internalMapEntry(tombstonedAt: nil, timeserial: "ts1", data: ObjectData(string: "existing"))],
                     objectID: "arbitrary",
                     logger: logger,
                     userCallbackQueue: .main,
@@ -713,7 +711,7 @@ struct InternalDefaultLiveMapTests {
                 )
 
                 // Apply operation with higher timeserial (ts2 > ts1), so can be applied per RTLM9
-                let update = map.testsOnly_applyMapRemoveOperation(key: "key1", operationTimeserial: "ts2")
+                let update = map.testsOnly_applyMapRemoveOperation(key: "key1", operationTimeserial: "ts2", operationSerialTimestamp: nil)
 
                 // Verify the operation was applied
                 #expect(try map.get(key: "key1", coreSDK: coreSDK, delegate: delegate) == nil)
@@ -747,7 +745,7 @@ struct InternalDefaultLiveMapTests {
                 let logger = TestLogger()
                 let map = InternalDefaultLiveMap.createZeroValued(objectID: "arbitrary", logger: logger, userCallbackQueue: .main, clock: MockSimpleClock())
 
-                let update = map.testsOnly_applyMapRemoveOperation(key: "newKey", operationTimeserial: "ts1")
+                let update = map.testsOnly_applyMapRemoveOperation(key: "newKey", operationTimeserial: "ts1", operationSerialTimestamp: nil)
 
                 // Verify new entry was created
                 let entry = map.testsOnly_data["newKey"]
@@ -769,7 +767,7 @@ struct InternalDefaultLiveMapTests {
                 let logger = TestLogger()
                 let map = InternalDefaultLiveMap.createZeroValued(objectID: "arbitrary", logger: logger, userCallbackQueue: .main, clock: MockSimpleClock())
 
-                _ = map.testsOnly_applyMapRemoveOperation(key: "newKey", operationTimeserial: "ts1")
+                _ = map.testsOnly_applyMapRemoveOperation(key: "newKey", operationTimeserial: "ts1", operationSerialTimestamp: nil)
 
                 // Verify tombstone is true for new entry
                 #expect(map.testsOnly_data["newKey"]?.tombstone == true)


### PR DESCRIPTION
**Note: This PR is based on top of #45; please review that one first.**

Implements https://github.com/ably/specification/pull/350. Have not yet done unit tests; have deferred those to #52, and will instead prioritise porting across the JS integration tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic cleanup (garbage collection) of deleted (tombstoned) objects and map entries after a configurable grace period.
  * Objects and map entries now track when they were deleted, improving state management and consistency.
  * Introduced explicit tombstone state and timestamp properties for live counters, maps, and entries.
  * Added support for tombstone-aware operations including object deletion and entry removal.
  * Enabled periodic background garbage collection of tombstoned objects in real-time objects.

* **Bug Fixes**
  * Improved handling of deleted objects to prevent unintended operations or data access.

* **Tests**
  * Updated tests to reflect new deletion tracking and cleanup logic.

* **Chores**
  * Enhanced internal logging for deletion and cleanup events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->