### PR TITLE
[ECO-5465] Enable disabled integration tests

### DIFF
--- a/Sources/AblyLiveObjects/Internal/CoreSDK.swift
+++ b/Sources/AblyLiveObjects/Internal/CoreSDK.swift
@@ -39,6 +39,7 @@ internal final class DefaultCoreSDK: CoreSDK {
         try await DefaultInternalPlugin.sendObject(
             objectMessages: objectMessages,
             channel: channel,
+            client: client,
             pluginAPI: pluginAPI,
         )
     }

--- a/Sources/AblyLiveObjects/Internal/CoreSDK.swift
+++ b/Sources/AblyLiveObjects/Internal/CoreSDK.swift
@@ -16,20 +16,25 @@ internal final class DefaultCoreSDK: CoreSDK {
     private let channel: AblyPlugin.RealtimeChannel
     private let client: AblyPlugin.RealtimeClient
     private let pluginAPI: PluginAPIProtocol
+    private let logger: AblyPlugin.Logger
 
     internal init(
         channel: AblyPlugin.RealtimeChannel,
         client: AblyPlugin.RealtimeClient,
-        pluginAPI: PluginAPIProtocol
+        pluginAPI: PluginAPIProtocol,
+        logger: AblyPlugin.Logger
     ) {
         self.channel = channel
         self.client = client
         self.pluginAPI = pluginAPI
+        self.logger = logger
     }
 
     // MARK: - CoreSDK conformance
 
     internal func publish(objectMessages: [OutboundObjectMessage]) async throws(InternalError) {
+        logger.log("publish(objectMessages: \(LoggingUtilities.formatObjectMessagesForLogging(objectMessages)))", level: .debug)
+
         // TODO: Implement the full spec of RTO15 (https://github.com/ably/ably-cocoa-liveobjects-plugin/issues/47)
         try await DefaultInternalPlugin.sendObject(
             objectMessages: objectMessages,

--- a/Sources/AblyLiveObjects/Internal/InternalDefaultLiveCounter.swift
+++ b/Sources/AblyLiveObjects/Internal/InternalDefaultLiveCounter.swift
@@ -80,12 +80,8 @@ internal final class InternalDefaultLiveCounter: Sendable {
     // MARK: - Internal methods that back LiveCounter conformance
 
     internal func value(coreSDK: CoreSDK) throws(ARTErrorInfo) -> Double {
-        // RTLC5b: If the channel is in the DETACHED or FAILED state, the library should indicate an error with code 90001
-        try coreSDK.validateChannelState(notIn: [.detached, .failed], operationDescription: "LiveCounter.value")
-
-        return mutex.withLock {
-            // RTLC5c
-            mutableState.data
+        try mutex.ablyLiveObjects_withLockWithTypedThrow { () throws(ARTErrorInfo) in
+            try mutableState.value(coreSDK: coreSDK)
         }
     }
 
@@ -418,6 +414,14 @@ internal final class InternalDefaultLiveCounter: Sendable {
         mutating func resetDataToZeroValued() {
             // RTLC4
             data = 0
+        }
+
+        internal func value(coreSDK: CoreSDK) throws(ARTErrorInfo) -> Double {
+            // RTLC5b: If the channel is in the DETACHED or FAILED state, the library should indicate an error with code 90001
+            try coreSDK.validateChannelState(notIn: [.detached, .failed], operationDescription: "LiveCounter.value")
+
+            // RTLC5c
+            return data
         }
     }
 }

--- a/Sources/AblyLiveObjects/Internal/InternalDefaultRealtimeObjects.swift
+++ b/Sources/AblyLiveObjects/Internal/InternalDefaultRealtimeObjects.swift
@@ -389,7 +389,7 @@ internal final class InternalDefaultRealtimeObjects: Sendable, LiveMapObjectPool
             clock: SimpleClock,
             receivedObjectSyncProtocolMessagesContinuation: AsyncStream<[InboundObjectMessage]>.Continuation,
         ) {
-            logger.log("handleObjectSyncProtocolMessage(objectMessages: \(objectMessages), protocolMessageChannelSerial: \(String(describing: protocolMessageChannelSerial)))", level: .debug)
+            logger.log("handleObjectSyncProtocolMessage(objectMessages: \(LoggingUtilities.formatObjectMessagesForLogging(objectMessages)), protocolMessageChannelSerial: \(String(describing: protocolMessageChannelSerial)))", level: .debug)
 
             receivedObjectSyncProtocolMessagesContinuation.yield(objectMessages)
 
@@ -489,7 +489,7 @@ internal final class InternalDefaultRealtimeObjects: Sendable, LiveMapObjectPool
         ) {
             receivedObjectProtocolMessagesContinuation.yield(objectMessages)
 
-            logger.log("handleObjectProtocolMessage(objectMessages: \(objectMessages))", level: .debug)
+            logger.log("handleObjectProtocolMessage(objectMessages: \(LoggingUtilities.formatObjectMessagesForLogging(objectMessages)))", level: .debug)
 
             if let existingSyncSequence = syncSequence {
                 // RTO8a: Buffer the OBJECT message, to be handled once the sync completes

--- a/Sources/AblyLiveObjects/Internal/InternalObjectsMapEntry.swift
+++ b/Sources/AblyLiveObjects/Internal/InternalObjectsMapEntry.swift
@@ -9,7 +9,7 @@ internal struct InternalObjectsMapEntry: Equatable {
     }
 
     internal var timeserial: String? // OME2b
-    internal var data: ObjectData // OME2c
+    internal var data: ObjectData? // OME2c
 }
 
 internal extension InternalObjectsMapEntry {

--- a/Sources/AblyLiveObjects/Protocol/ObjectMessage.swift
+++ b/Sources/AblyLiveObjects/Protocol/ObjectMessage.swift
@@ -490,6 +490,25 @@ extension InboundObjectMessage: CustomDebugStringConvertible {
     }
 }
 
+extension OutboundObjectMessage: CustomDebugStringConvertible {
+    internal var debugDescription: String {
+        var parts: [String] = []
+
+        if let id { parts.append("id: \(id)") }
+        if let clientId { parts.append("clientId: \(clientId)") }
+        if let connectionId { parts.append("connectionId: \(connectionId)") }
+        if let extras { parts.append("extras: \(extras)") }
+        if let timestamp { parts.append("timestamp: \(timestamp)") }
+        if let operation { parts.append("operation: \(operation)") }
+        if let object { parts.append("object: \(object)") }
+        if let serial { parts.append("serial: \(serial)") }
+        if let siteCode { parts.append("siteCode: \(siteCode)") }
+        if let serialTimestamp { parts.append("serialTimestamp: \(serialTimestamp)") }
+
+        return "{ " + parts.joined(separator: ", ") + " }"
+    }
+}
+
 extension ObjectOperation: CustomDebugStringConvertible {
     internal var debugDescription: String {
         var parts: [String] = []

--- a/Sources/AblyLiveObjects/Protocol/ObjectMessage.swift
+++ b/Sources/AblyLiveObjects/Protocol/ObjectMessage.swift
@@ -468,3 +468,113 @@ internal extension ObjectState {
         )
     }
 }
+
+// MARK: - CustomDebugStringConvertible
+
+extension InboundObjectMessage: CustomDebugStringConvertible {
+    internal var debugDescription: String {
+        var parts: [String] = []
+
+        if let id { parts.append("id: \(id)") }
+        if let clientId { parts.append("clientId: \(clientId)") }
+        if let connectionId { parts.append("connectionId: \(connectionId)") }
+        if let extras { parts.append("extras: \(extras)") }
+        if let timestamp { parts.append("timestamp: \(timestamp)") }
+        if let operation { parts.append("operation: \(operation)") }
+        if let object { parts.append("object: \(object)") }
+        if let serial { parts.append("serial: \(serial)") }
+        if let siteCode { parts.append("siteCode: \(siteCode)") }
+        if let serialTimestamp { parts.append("serialTimestamp: \(serialTimestamp)") }
+
+        return "{ " + parts.joined(separator: ", ") + " }"
+    }
+}
+
+extension ObjectOperation: CustomDebugStringConvertible {
+    internal var debugDescription: String {
+        var parts: [String] = []
+
+        parts.append("action: \(action)")
+        parts.append("objectId: \(objectId)")
+        if let mapOp { parts.append("mapOp: \(mapOp)") }
+        if let counterOp { parts.append("counterOp: \(counterOp)") }
+        if let map { parts.append("map: \(map)") }
+        if let counter { parts.append("counter: \(counter)") }
+        if let nonce { parts.append("nonce: \(nonce)") }
+        if let initialValue { parts.append("initialValue: \(initialValue)") }
+
+        return "{ " + parts.joined(separator: ", ") + " }"
+    }
+}
+
+extension ObjectState: CustomDebugStringConvertible {
+    internal var debugDescription: String {
+        var parts: [String] = []
+
+        parts.append("objectId: \(objectId)")
+        parts.append("siteTimeserials: \(siteTimeserials)")
+        parts.append("tombstone: \(tombstone)")
+        if let createOp { parts.append("createOp: \(createOp)") }
+        if let map { parts.append("map: \(map)") }
+        if let counter { parts.append("counter: \(counter)") }
+
+        return "{ " + parts.joined(separator: ", ") + " }"
+    }
+}
+
+extension ObjectsMapOp: CustomDebugStringConvertible {
+    internal var debugDescription: String {
+        var parts: [String] = []
+
+        parts.append("key: \(key)")
+        if let data { parts.append("data: \(data)") }
+
+        return "{ " + parts.joined(separator: ", ") + " }"
+    }
+}
+
+extension ObjectsMap: CustomDebugStringConvertible {
+    internal var debugDescription: String {
+        var parts: [String] = []
+
+        parts.append("semantics: \(semantics)")
+        if let entries {
+            let formattedEntries = entries
+                .map { key, entry in
+                    "\(key): \(entry)"
+                }
+                .joined(separator: ", ")
+            parts.append("entries: { \(formattedEntries) }")
+        }
+
+        return "{ " + parts.joined(separator: ", ") + " }"
+    }
+}
+
+extension ObjectsMapEntry: CustomDebugStringConvertible {
+    internal var debugDescription: String {
+        var parts: [String] = []
+
+        if let tombstone { parts.append("tombstone: \(tombstone)") }
+        if let timeserial { parts.append("timeserial: \(timeserial)") }
+        parts.append("data: \(data)")
+        if let serialTimestamp { parts.append("serialTimestamp: \(serialTimestamp)") }
+
+        return "{ " + parts.joined(separator: ", ") + " }"
+    }
+}
+
+extension ObjectData: CustomDebugStringConvertible {
+    internal var debugDescription: String {
+        var parts: [String] = []
+
+        if let objectId { parts.append("objectId: \(objectId)") }
+        if let boolean { parts.append("boolean: \(boolean)") }
+        if let bytes { parts.append("bytes: \(bytes.count) bytes") }
+        if let number { parts.append("number: \(number)") }
+        if let string { parts.append("string: \(string)") }
+        if let json { parts.append("json: \(json)") }
+
+        return "{ " + parts.joined(separator: ", ") + " }"
+    }
+}

--- a/Sources/AblyLiveObjects/Protocol/ObjectMessage.swift
+++ b/Sources/AblyLiveObjects/Protocol/ObjectMessage.swift
@@ -71,7 +71,7 @@ internal struct ObjectsMapOp: Equatable {
 internal struct ObjectsMapEntry: Equatable {
     internal var tombstone: Bool? // OME2a
     internal var timeserial: String? // OME2b
-    internal var data: ObjectData // OME2c
+    internal var data: ObjectData? // OME2c
     internal var serialTimestamp: Date? // OME2d
 }
 
@@ -386,7 +386,11 @@ internal extension ObjectsMapEntry {
     ) throws(InternalError) {
         tombstone = wireObjectsMapEntry.tombstone
         timeserial = wireObjectsMapEntry.timeserial
-        data = try .init(wireObjectData: wireObjectsMapEntry.data, format: format)
+        data = if let wireObjectData = wireObjectsMapEntry.data {
+            try .init(wireObjectData: wireObjectData, format: format)
+        } else {
+            nil
+        }
         serialTimestamp = wireObjectsMapEntry.serialTimestamp
     }
 
@@ -398,7 +402,7 @@ internal extension ObjectsMapEntry {
         .init(
             tombstone: tombstone,
             timeserial: timeserial,
-            data: data.toWire(format: format),
+            data: data?.toWire(format: format),
         )
     }
 }
@@ -576,7 +580,7 @@ extension ObjectsMapEntry: CustomDebugStringConvertible {
 
         if let tombstone { parts.append("tombstone: \(tombstone)") }
         if let timeserial { parts.append("timeserial: \(timeserial)") }
-        parts.append("data: \(data)")
+        if let data { parts.append("data: \(data)") }
         if let serialTimestamp { parts.append("serialTimestamp: \(serialTimestamp)") }
 
         return "{ " + parts.joined(separator: ", ") + " }"

--- a/Sources/AblyLiveObjects/Protocol/WireObjectMessage.swift
+++ b/Sources/AblyLiveObjects/Protocol/WireObjectMessage.swift
@@ -555,3 +555,49 @@ internal enum StringOrData: WireCodable {
         }
     }
 }
+
+// MARK: - CustomDebugStringConvertible
+
+extension WireObjectsCounter: CustomDebugStringConvertible {
+    internal var debugDescription: String {
+        if let count {
+            "{ count: \(count) }"
+        } else {
+            "{ count: nil }"
+        }
+    }
+}
+
+extension WireObjectsCounterOp: CustomDebugStringConvertible {
+    internal var debugDescription: String {
+        "{ amount: \(amount) }"
+    }
+}
+
+extension WireObjectsMapEntry: CustomDebugStringConvertible {
+    internal var debugDescription: String {
+        var parts: [String] = []
+
+        if let tombstone { parts.append("tombstone: \(tombstone)") }
+        if let timeserial { parts.append("timeserial: \(timeserial)") }
+        parts.append("data: \(data)")
+        if let serialTimestamp { parts.append("serialTimestamp: \(serialTimestamp)") }
+
+        return "{ " + parts.joined(separator: ", ") + " }"
+    }
+}
+
+extension WireObjectData: CustomDebugStringConvertible {
+    internal var debugDescription: String {
+        var parts: [String] = []
+
+        if let objectId { parts.append("objectId: \(objectId)") }
+        if let boolean { parts.append("boolean: \(boolean)") }
+        if let bytes { parts.append("bytes: \(bytes)") }
+        if let number { parts.append("number: \(number)") }
+        if let string { parts.append("string: \(string)") }
+        if let json { parts.append("json: \(json)") }
+
+        return "{ " + parts.joined(separator: ", ") + " }"
+    }
+}

--- a/Sources/AblyLiveObjects/Protocol/WireObjectMessage.swift
+++ b/Sources/AblyLiveObjects/Protocol/WireObjectMessage.swift
@@ -431,7 +431,7 @@ extension WireObjectsCounter: WireObjectCodable {
 internal struct WireObjectsMapEntry {
     internal var tombstone: Bool? // OME2a
     internal var timeserial: String? // OME2b
-    internal var data: WireObjectData // OME2c
+    internal var data: WireObjectData? // OME2c
     internal var serialTimestamp: Date? // OME2d
 }
 
@@ -446,15 +446,16 @@ extension WireObjectsMapEntry: WireObjectCodable {
     internal init(wireObject: [String: WireValue]) throws(InternalError) {
         tombstone = try wireObject.optionalBoolValueForKey(WireKey.tombstone.rawValue)
         timeserial = try wireObject.optionalStringValueForKey(WireKey.timeserial.rawValue)
-        data = try wireObject.decodableValueForKey(WireKey.data.rawValue)
+        data = try wireObject.optionalDecodableValueForKey(WireKey.data.rawValue)
         serialTimestamp = try wireObject.optionalAblyProtocolDateValueForKey(WireKey.serialTimestamp.rawValue)
     }
 
     internal var toWireObject: [String: WireValue] {
-        var result: [String: WireValue] = [
-            WireKey.data.rawValue: .object(data.toWireObject),
-        ]
+        var result: [String: WireValue] = [:]
 
+        if let data {
+            result[WireKey.data.rawValue] = .object(data.toWireObject)
+        }
         if let tombstone {
             result[WireKey.tombstone.rawValue] = .bool(tombstone)
         }
@@ -580,7 +581,7 @@ extension WireObjectsMapEntry: CustomDebugStringConvertible {
 
         if let tombstone { parts.append("tombstone: \(tombstone)") }
         if let timeserial { parts.append("timeserial: \(timeserial)") }
-        parts.append("data: \(data)")
+        if let data { parts.append("data: \(data)") }
         if let serialTimestamp { parts.append("serialTimestamp: \(serialTimestamp)") }
 
         return "{ " + parts.joined(separator: ", ") + " }"

--- a/Sources/AblyLiveObjects/Public/ARTRealtimeChannel+Objects.swift
+++ b/Sources/AblyLiveObjects/Public/ARTRealtimeChannel+Objects.swift
@@ -12,13 +12,14 @@ public extension ARTRealtimeChannel {
         let underlyingObjects = pluginAPI.underlyingObjects(forPublicRealtimeChannel: self)
         let internalObjects = DefaultInternalPlugin.realtimeObjects(for: underlyingObjects.channel, pluginAPI: pluginAPI)
 
+        let logger = pluginAPI.logger(for: underlyingObjects.channel)
+
         let coreSDK = DefaultCoreSDK(
             channel: underlyingObjects.channel,
             client: underlyingObjects.client,
             pluginAPI: Plugin.defaultPluginAPI,
+            logger: logger,
         )
-
-        let logger = pluginAPI.logger(for: underlyingObjects.channel)
 
         return PublicObjectsStore.shared.getOrCreateRealtimeObjects(
             proxying: internalObjects,

--- a/Sources/AblyLiveObjects/Utility/LoggingUtilities.swift
+++ b/Sources/AblyLiveObjects/Utility/LoggingUtilities.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+internal enum LoggingUtilities {
+    /// Formats an array of object messages for logging with one message per line.
+    /// - Parameter objectMessages: The array of object messages to format
+    /// - Returns: A formatted string with one message per line
+    internal static func formatObjectMessagesForLogging(_ objectMessages: [some CustomDebugStringConvertible]) -> String {
+        guard !objectMessages.isEmpty else {
+            return "[]"
+        }
+
+        return "[\n" + objectMessages.map { "  \($0)" }.joined(separator: ",\n") + "\n]"
+    }
+}

--- a/Tests/AblyLiveObjectsTests/Helpers/ClientHelper.swift
+++ b/Tests/AblyLiveObjectsTests/Helpers/ClientHelper.swift
@@ -22,8 +22,41 @@ enum ClientHelper {
         if let autoConnect = options.autoConnect {
             clientOptions.autoConnect = autoConnect
         }
+        if let logIdentifier = options.logIdentifier {
+            let logger = PrefixedLogger(prefix: "(\(logIdentifier)) ")
+            clientOptions.logHandler = logger
+        }
 
         return ARTRealtime(options: clientOptions)
+    }
+
+    /// An ably-cocoa logger that adds a given prefix to all emitted log messages.
+    private class PrefixedLogger: ARTLog {
+        // This dance of using an implicitly unwrapped optional instead of a `let` is because we can't write a custom designated initializer (see comment below).
+        var _prefix: String!
+        var prefix: String {
+            get {
+                _prefix
+            }
+
+            set {
+                if _prefix != nil {
+                    fatalError("PrefixedLogger prefix cannot be changed after initialization")
+                }
+                _prefix = newValue
+            }
+        }
+
+        // We use a convenience initializer because it's not clear to a consumer of the public API how to implement a custom designated initializer (super.init delegates to the non-public init(capturingOutput:).
+        convenience init(prefix: String) {
+            self.init()
+            self.prefix = prefix
+        }
+
+        override public func log(_ message: String, with level: ARTLogLevel) {
+            let newMessage = "\(prefix)\(message)"
+            super.log(newMessage, with: level)
+        }
     }
 
     /// Creates channel options that include the channel modes needed for LiveObjects.
@@ -36,5 +69,8 @@ enum ClientHelper {
     struct PartialClientOptions: Encodable, Hashable {
         var useBinaryProtocol: Bool?
         var autoConnect: Bool?
+
+        /// A prefix for all log messages emitted by the client. Allows clients to be distinguished in log messages for tests which use multiple clients.
+        var logIdentifier: String?
     }
 }

--- a/Tests/AblyLiveObjectsTests/Helpers/TestFactories.swift
+++ b/Tests/AblyLiveObjectsTests/Helpers/TestFactories.swift
@@ -393,7 +393,7 @@ struct TestFactories {
     static func mapEntry(
         tombstone: Bool? = false,
         timeserial: String? = "ts1",
-        data: ObjectData,
+        data: ObjectData?,
     ) -> ObjectsMapEntry {
         ObjectsMapEntry(
             tombstone: tombstone,

--- a/Tests/AblyLiveObjectsTests/InternalDefaultLiveMapTests.swift
+++ b/Tests/AblyLiveObjectsTests/InternalDefaultLiveMapTests.swift
@@ -534,8 +534,8 @@ struct InternalDefaultLiveMapTests {
                 }
 
                 // RTLM7a2a: Set ObjectsMapEntry.data to the ObjectData from the operation
-                #expect(map.testsOnly_data["key1"]?.data.number == operationData.number)
-                #expect(map.testsOnly_data["key1"]?.data.objectId == operationData.objectId)
+                #expect(map.testsOnly_data["key1"]?.data?.number == operationData.number)
+                #expect(map.testsOnly_data["key1"]?.data?.objectId == operationData.objectId)
 
                 // RTLM7a2b: Set ObjectsMapEntry.timeserial to the operation's serial
                 #expect(map.testsOnly_data["key1"]?.timeserial == "ts2")
@@ -717,12 +717,7 @@ struct InternalDefaultLiveMapTests {
                 #expect(try map.get(key: "key1", coreSDK: coreSDK, delegate: delegate) == nil)
 
                 // RTLM8a2a: Set ObjectsMapEntry.data to undefined/null
-                let entry = map.testsOnly_data["key1"]
-                #expect(entry?.data.string == nil)
-                #expect(entry?.data.number == nil)
-                #expect(entry?.data.boolean == nil)
-                #expect(entry?.data.bytes == nil)
-                #expect(entry?.data.objectId == nil)
+                #expect(map.testsOnly_data["key1"]?.data == nil)
 
                 // RTLM8a2b: Set ObjectsMapEntry.timeserial to the operation's serial
                 #expect(map.testsOnly_data["key1"]?.timeserial == "ts2")
@@ -751,11 +746,7 @@ struct InternalDefaultLiveMapTests {
                 let entry = map.testsOnly_data["newKey"]
                 #expect(entry != nil)
                 #expect(entry?.timeserial == "ts1")
-                #expect(entry?.data.string == nil)
-                #expect(entry?.data.number == nil)
-                #expect(entry?.data.boolean == nil)
-                #expect(entry?.data.bytes == nil)
-                #expect(entry?.data.objectId == nil)
+                #expect(entry?.data == nil)
 
                 // RTLM8e: Check return value
                 #expect(try #require(update.update).update == ["newKey": .removed])

--- a/Tests/AblyLiveObjectsTests/JS Integration Tests/ObjectsIntegrationTests.swift
+++ b/Tests/AblyLiveObjectsTests/JS Integration Tests/ObjectsIntegrationTests.swift
@@ -226,6 +226,7 @@ private actor ObjectsFixturesTrait: SuiteTrait, TestScoping {
                     try await helper.initForChannel(objectsFixturesChannel)
                 }
             }
+            self.setupTask = setupTask
 
             try await setupTask.value
         }

--- a/Tests/AblyLiveObjectsTests/JS Integration Tests/ObjectsIntegrationTests.swift
+++ b/Tests/AblyLiveObjectsTests/JS Integration Tests/ObjectsIntegrationTests.swift
@@ -293,7 +293,7 @@ private struct ObjectsIntegrationTests {
                     },
                 ),
                 .init(
-                    disabled: true, // Uses LiveMap.set which we haven't implemented yet
+                    disabled: false,
                     allTransportsAndProtocols: true,
                     description: "OBJECT_SYNC sequence builds object tree with all operations applied",
                     action: { ctx in
@@ -368,7 +368,7 @@ private struct ObjectsIntegrationTests {
                     },
                 ),
                 .init(
-                    disabled: true, // Uses LiveMap.set which we haven't implemented yet
+                    disabled: false,
                     allTransportsAndProtocols: false,
                     description: "OBJECT_SYNC sequence does not change references to existing objects",
                     action: { ctx in
@@ -510,7 +510,7 @@ private struct ObjectsIntegrationTests {
                     },
                 ),
                 .init(
-                    disabled: true, // This relies on the LiveMap.get returning `nil` when the referenced object's internal `tombstone` flag is true; this is not yet specified, have asked in https://ably-real-time.slack.com/archives/D067YAXGYQ5/p1751376526929339
+                    disabled: false,
                     allTransportsAndProtocols: false,
                     description: "OBJECT_SYNC sequence with object state \"tombstone\" property creates tombstoned object",
                     action: { ctx in
@@ -566,7 +566,7 @@ private struct ObjectsIntegrationTests {
                     },
                 ),
                 .init(
-                    disabled: true, // Uses LiveMap.subscribe (through waitForMapKeyUpdate) which we haven't implemented yet. It also seems to rely on the same internal `tombstone` flag as the previous test.
+                    disabled: false,
                     allTransportsAndProtocols: true,
                     description: "OBJECT_SYNC sequence with object state \"tombstone\" property deletes existing object",
                     action: { ctx in
@@ -621,7 +621,7 @@ private struct ObjectsIntegrationTests {
                     },
                 ),
                 .init(
-                    disabled: true, // Uses LiveMap.subscribe (through waitForMapKeyUpdate) which we haven't implemented yet
+                    disabled: false,
                     allTransportsAndProtocols: true,
                     description: "OBJECT_SYNC sequence with object state \"tombstone\" property triggers subscription callback for existing object",
                     action: { ctx in

--- a/Tests/AblyLiveObjectsTests/JS Integration Tests/ObjectsIntegrationTests.swift
+++ b/Tests/AblyLiveObjectsTests/JS Integration Tests/ObjectsIntegrationTests.swift
@@ -177,17 +177,21 @@ private struct TestScenario<Context> {
 
 private func forScenarios<Context>(_ scenarios: [TestScenario<Context>]) -> [TestCase<Context>] {
     scenarios.map { scenario -> [TestCase<Context>] in
+        var clientOptions = ClientHelper.PartialClientOptions(logIdentifier: "client1")
+
         if scenario.allTransportsAndProtocols {
-            [true, false].map { useBinaryProtocol -> TestCase<Context> in
-                .init(
+            return [true, false].map { useBinaryProtocol -> TestCase<Context> in
+                clientOptions.useBinaryProtocol = useBinaryProtocol
+
+                return .init(
                     disabled: scenario.disabled,
                     scenario: scenario,
-                    options: .init(useBinaryProtocol: useBinaryProtocol),
+                    options: clientOptions,
                     channelName: "\(scenario.description) \(useBinaryProtocol ? "binary" : "text")",
                 )
             }
         } else {
-            [.init(disabled: scenario.disabled, scenario: scenario, options: .init(), channelName: scenario.description)]
+            return [.init(disabled: scenario.disabled, scenario: scenario, options: clientOptions, channelName: scenario.description)]
         }
     }
     .flatMap(\.self)

--- a/Tests/AblyLiveObjectsTests/WireObjectMessageTests.swift
+++ b/Tests/AblyLiveObjectsTests/WireObjectMessageTests.swift
@@ -180,7 +180,7 @@ enum WireObjectMessageTests {
             #expect(op.mapOp?.data?.string == "value1")
             #expect(op.counterOp?.amount == 42)
             #expect(op.map?.semantics == .known(.lww))
-            #expect(op.map?.entries?["key1"]?.data.string == "value1")
+            #expect(op.map?.entries?["key1"]?.data?.string == "value1")
             #expect(op.map?.entries?["key1"]?.tombstone == false)
             #expect(op.counter?.count == 42)
 
@@ -282,7 +282,7 @@ enum WireObjectMessageTests {
             #expect(state.createOp?.action == .known(.mapCreate))
             #expect(state.createOp?.objectId == "obj1")
             #expect(state.map?.semantics == .known(.lww))
-            #expect(state.map?.entries?["key1"]?.data.string == "value1")
+            #expect(state.map?.entries?["key1"]?.data?.string == "value1")
             #expect(state.map?.entries?["key1"]?.tombstone == false)
             #expect(state.counter?.count == 42)
         }
@@ -488,10 +488,10 @@ enum WireObjectMessageTests {
             ]
             let map = try WireObjectsMap(wireObject: json)
             #expect(map.semantics == .known(.lww))
-            #expect(map.entries?["key1"]?.data.string == "value1")
+            #expect(map.entries?["key1"]?.data?.string == "value1")
             #expect(map.entries?["key1"]?.tombstone == false)
             #expect(map.entries?["key1"]?.timeserial == "ts1")
-            #expect(map.entries?["key2"]?.data.string == "value2")
+            #expect(map.entries?["key2"]?.data?.string == "value2")
             #expect(map.entries?["key2"]?.tombstone == true)
             #expect(map.entries?["key2"]?.timeserial == nil)
         }
@@ -584,7 +584,7 @@ enum WireObjectMessageTests {
                 "timeserial": "ts1",
             ]
             let entry = try WireObjectsMapEntry(wireObject: json)
-            #expect(entry.data.string == "value1")
+            #expect(entry.data?.string == "value1")
             #expect(entry.tombstone == true)
             #expect(entry.timeserial == "ts1")
         }
@@ -593,7 +593,7 @@ enum WireObjectMessageTests {
         func decodesWithOptionalFieldsAbsent() throws {
             let json: [String: WireValue] = ["data": ["string": "value1"]]
             let entry = try WireObjectsMapEntry(wireObject: json)
-            #expect(entry.data.string == "value1")
+            #expect(entry.data?.string == "value1")
             #expect(entry.tombstone == nil)
             #expect(entry.timeserial == nil)
         }


### PR DESCRIPTION
**Note: This PR is based on top of #51; please review that one first.**

This enables the integration tests that I'd ported from JS in https://github.com/ably/ably-cocoa-liveobjects-plugin/commit/fa255c1e98f61aa65d40d7a66edcfb9b71a798ca but which were disabled because the features they depended on hadn't been implemented yet. The enabling of the tests is preceded by some improvements to logging (which I used to help me debug some failing tests), and some fixes for test failures. See commit messages for more details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced logging with improved formatting for object messages and added detailed debug descriptions for key objects.
  * Logging can now be prefixed with a custom identifier in test clients.

* **Refactor**
  * Centralized map and counter logic within internal state structures for improved modularity and maintainability.
  * Simplified and streamlined asynchronous test helpers using modern async sequence patterns.

* **Bug Fixes**
  * Improved handling of optional data fields in maps and protocol messages to prevent errors and ensure correct behavior.

* **Tests**
  * Updated and enabled tests to reflect changes in data handling and logging, ensuring more robust and accurate test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->