### PR TITLE
[ECO-5465] Port remaining high-value JS integration tests

### DIFF
--- a/Sources/AblyLiveObjects/Internal/ARTClientOptions+Objects.swift
+++ b/Sources/AblyLiveObjects/Internal/ARTClientOptions+Objects.swift
@@ -1,0 +1,45 @@
+internal import AblyPlugin
+
+internal extension ARTClientOptions {
+    private class Box<T> {
+        internal let boxed: T
+
+        internal init(boxed: T) {
+            self.boxed = boxed
+        }
+    }
+
+    private static let garbageCollectionOptionsKey = "Objects.garbageCollectionOptions"
+
+    /// Can be overriden for testing purposes.
+    var garbageCollectionOptions: InternalDefaultRealtimeObjects.GarbageCollectionOptions? {
+        get {
+            let optionsValue = PluginAPI.sharedInstance().pluginOptionsValue(
+                forKey: Self.garbageCollectionOptionsKey,
+                clientOptions: self,
+            )
+
+            guard let optionsValue else {
+                return nil
+            }
+
+            guard let box = optionsValue as? Box<InternalDefaultRealtimeObjects.GarbageCollectionOptions> else {
+                preconditionFailure("Expected GarbageCollectionOptionsBox, got \(optionsValue)")
+            }
+
+            return box.boxed
+        }
+
+        set {
+            guard let newValue else {
+                preconditionFailure("Not implemented the ability to un-set GC options")
+            }
+
+            PluginAPI.sharedInstance().setPluginOptionsValue(
+                Box<InternalDefaultRealtimeObjects.GarbageCollectionOptions>(boxed: newValue),
+                forKey: Self.garbageCollectionOptionsKey,
+                clientOptions: self,
+            )
+        }
+    }
+}

--- a/Sources/AblyLiveObjects/Internal/DefaultInternalPlugin.swift
+++ b/Sources/AblyLiveObjects/Internal/DefaultInternalPlugin.swift
@@ -36,9 +36,15 @@ internal final class DefaultInternalPlugin: NSObject, AblyPlugin.LiveObjectsInte
     internal func prepare(_ channel: AblyPlugin.RealtimeChannel, client: AblyPlugin.RealtimeClient) {
         let logger = pluginAPI.logger(for: channel)
         let callbackQueue = pluginAPI.callbackQueue(for: client)
+        let options = pluginAPI.options(for: client)
 
         logger.log("LiveObjects.DefaultInternalPlugin received prepare(_:)", level: .debug)
-        let liveObjects = InternalDefaultRealtimeObjects(logger: logger, userCallbackQueue: callbackQueue, clock: DefaultSimpleClock())
+        let liveObjects = InternalDefaultRealtimeObjects(
+            logger: logger,
+            userCallbackQueue: callbackQueue,
+            clock: DefaultSimpleClock(),
+            garbageCollectionOptions: options.garbageCollectionOptions ?? .init(),
+        )
         pluginAPI.setPluginDataValue(liveObjects, forKey: Self.pluginDataKey, channel: channel)
     }
 

--- a/Sources/AblyLiveObjects/Internal/InternalDefaultRealtimeObjects.swift
+++ b/Sources/AblyLiveObjects/Internal/InternalDefaultRealtimeObjects.swift
@@ -26,7 +26,7 @@ internal final class InternalDefaultRealtimeObjects: Sendable, LiveMapObjectPool
     private nonisolated(unsafe) var garbageCollectionTask: Task<Void, Never>!
 
     /// Parameters used to control the garbage collection of tombstoned objects and map entries, as described in RTO10.
-    internal struct GarbageCollectionOptions {
+    internal struct GarbageCollectionOptions: Encodable, Hashable {
         /// The RTO10a interval at which we will perform garbage collection.
         ///
         /// The default value comes from the suggestion in RTO10a.

--- a/Sources/AblyLiveObjects/Internal/InternalDefaultRealtimeObjects.swift
+++ b/Sources/AblyLiveObjects/Internal/InternalDefaultRealtimeObjects.swift
@@ -98,6 +98,7 @@ internal final class InternalDefaultRealtimeObjects: Sendable, LiveMapObjectPool
         (receivedObjectProtocolMessages, receivedObjectProtocolMessagesContinuation) = AsyncStream.makeStream()
         (receivedObjectSyncProtocolMessages, receivedObjectSyncProtocolMessagesContinuation) = AsyncStream.makeStream()
         (waitingForSyncEvents, waitingForSyncEventsContinuation) = AsyncStream.makeStream()
+        (completedGarbageCollectionEvents, completedGarbageCollectionsEventsContinuation) = AsyncStream.makeStream()
         mutableState = .init(objectsPool: .init(logger: logger, userCallbackQueue: userCallbackQueue, clock: clock))
         garbageCollectionInterval = garbageCollectionOptions.interval
         garbageCollectionGracePeriod = garbageCollectionOptions.gracePeriod
@@ -331,8 +332,17 @@ internal final class InternalDefaultRealtimeObjects: Sendable, LiveMapObjectPool
                 gracePeriod: garbageCollectionGracePeriod,
                 clock: clock,
                 logger: logger,
+                eventsContinuation: completedGarbageCollectionsEventsContinuation,
             )
         }
+    }
+
+    // These drive the testsOnly_completedGarbageCollectionEvents property that informs the test suite when a garbage collection cycle has completed.
+    private let completedGarbageCollectionEvents: AsyncStream<Void>
+    private let completedGarbageCollectionsEventsContinuation: AsyncStream<Void>.Continuation
+    /// Emits an element whenever a garbage collection cycle has completed.
+    internal var testsOnly_completedGarbageCollectionEvents: AsyncStream<Void> {
+        completedGarbageCollectionEvents
     }
 
     // MARK: - Testing
@@ -342,10 +352,12 @@ internal final class InternalDefaultRealtimeObjects: Sendable, LiveMapObjectPool
     /// - testsOnly_receivedObjectProtocolMessages
     /// - testsOnly_receivedObjectStateProtocolMessages
     /// - testsOnly_waitingForSyncEvents
+    /// - testsOnly_completedGarbageCollectionEvents
     internal func testsOnly_finishAllTestHelperStreams() {
         receivedObjectProtocolMessagesContinuation.finish()
         receivedObjectSyncProtocolMessagesContinuation.finish()
         waitingForSyncEventsContinuation.finish()
+        completedGarbageCollectionsEventsContinuation.finish()
     }
 
     // MARK: - Mutable state and the operations that affect it

--- a/Sources/AblyLiveObjects/Internal/ObjectsPool.swift
+++ b/Sources/AblyLiveObjects/Internal/ObjectsPool.swift
@@ -408,7 +408,12 @@ internal struct ObjectsPool {
     }
 
     /// Performs garbage collection of tombstoned objects and map entries, per RTO10c.
-    internal mutating func performGarbageCollection(gracePeriod: TimeInterval, clock: SimpleClock, logger: Logger) {
+    internal mutating func performGarbageCollection(
+        gracePeriod: TimeInterval,
+        clock: SimpleClock,
+        logger: Logger,
+        eventsContinuation: AsyncStream<Void>.Continuation,
+    ) {
         logger.log("Performing garbage collection, grace period \(gracePeriod)s", level: .debug)
 
         let now = clock.now
@@ -433,5 +438,7 @@ internal struct ObjectsPool {
             }
             return !shouldRelease
         }
+
+        eventsContinuation.yield()
     }
 }

--- a/Sources/AblyLiveObjects/Public/Public Proxy Objects/PublicDefaultRealtimeObjects.swift
+++ b/Sources/AblyLiveObjects/Public/Public Proxy Objects/PublicDefaultRealtimeObjects.swift
@@ -117,4 +117,13 @@ internal final class PublicDefaultRealtimeObjects: RealtimeObjects {
     internal var testsOnly_receivedObjectSyncProtocolMessages: AsyncStream<[InboundObjectMessage]> {
         proxied.testsOnly_receivedObjectSyncProtocolMessages
     }
+
+    // These are used by the integration tests.
+
+    /// Replaces the method that this `RealtimeObjects` uses to send any outbound `ObjectMessage`s.
+    ///
+    /// Used by integration tests, for example to disable `ObjectMessage` publishing so that a test can verify that a behaviour is not a side effect of an `ObjectMessage` sent by the SDK.
+    internal func testsOnly_overridePublish(with newImplementation: @escaping ([OutboundObjectMessage]) async throws(InternalError) -> Void) {
+        coreSDK.testsOnly_overridePublish(with: newImplementation)
+    }
 }

--- a/Sources/AblyLiveObjects/Utility/ExtendedJSONValue.swift
+++ b/Sources/AblyLiveObjects/Utility/ExtendedJSONValue.swift
@@ -43,7 +43,7 @@ internal extension ExtendedJSONValue {
 
     /// Converts an `ExtendedJSONValue` to an object.
     ///
-    /// The contract for what this will return are the same as those of `JSONValue.toJSONSerializationInputElemtn`, with one addition: any values in the input of case `.extra` will be passed to the `serializeExtraValue` function, and the result of this function call will be inserted into the output object.
+    /// The contract for what this will return are the same as those of `JSONValue.toJSONSerializationInputElement`, with one addition: any values in the input of case `.extra` will be passed to the `serializeExtraValue` function, and the result of this function call will be inserted into the output object.
     func serialized(serializeExtraValue: (Extra) -> Any) -> Any {
         switch self {
         case let .object(underlying):

--- a/Tests/AblyLiveObjectsTests/Helpers/ClientHelper.swift
+++ b/Tests/AblyLiveObjectsTests/Helpers/ClientHelper.swift
@@ -1,5 +1,5 @@
 import Ably
-import AblyLiveObjects
+@testable import AblyLiveObjects
 
 /// Helper for creating ably-cocoa objects, for use in integration tests.
 enum ClientHelper {
@@ -25,6 +25,9 @@ enum ClientHelper {
         if let logIdentifier = options.logIdentifier {
             let logger = PrefixedLogger(prefix: "(\(logIdentifier)) ")
             clientOptions.logHandler = logger
+        }
+        if let garbageCollectionOptions = options.garbageCollectionOptions {
+            clientOptions.garbageCollectionOptions = garbageCollectionOptions
         }
 
         return ARTRealtime(options: clientOptions)
@@ -69,6 +72,7 @@ enum ClientHelper {
     struct PartialClientOptions: Encodable, Hashable {
         var useBinaryProtocol: Bool?
         var autoConnect: Bool?
+        var garbageCollectionOptions: InternalDefaultRealtimeObjects.GarbageCollectionOptions?
 
         /// A prefix for all log messages emitted by the client. Allows clients to be distinguished in log messages for tests which use multiple clients.
         var logIdentifier: String?

--- a/Tests/AblyLiveObjectsTests/JS Integration Tests/ObjectsHelper.swift
+++ b/Tests/AblyLiveObjectsTests/JS Integration Tests/ObjectsHelper.swift
@@ -445,7 +445,7 @@ final class ObjectsHelper: Sendable {
     }
 
     /// Creates a counter create REST operation
-    func counterCreateRestOp(objectId: String? = nil, nonce: String? = nil, number: Int? = nil) -> [String: JSONValue] {
+    func counterCreateRestOp(objectId: String? = nil, nonce: String? = nil, number: Double? = nil) -> [String: JSONValue] {
         var opBody: [String: JSONValue] = [
             "operation": .string(Actions.counterCreate.stringValue),
         ]
@@ -463,7 +463,7 @@ final class ObjectsHelper: Sendable {
     }
 
     /// Creates a counter increment REST operation
-    func counterIncRestOp(objectId: String, number: Int) -> [String: JSONValue] {
+    func counterIncRestOp(objectId: String, number: Double) -> [String: JSONValue] {
         [
             "operation": .string(Actions.counterInc.stringValue),
             "objectId": .string(objectId),

--- a/Tests/AblyLiveObjectsTests/JS Integration Tests/ObjectsHelper.swift
+++ b/Tests/AblyLiveObjectsTests/JS Integration Tests/ObjectsHelper.swift
@@ -345,7 +345,7 @@ final class ObjectsHelper: Sendable {
         serial: String,
         siteCode: String,
         state: [[String: JSONValue]]? = nil,
-    ) async throws {
+    ) async {
         await processDeserializedProtocolMessage(
             objectOperationMessage(
                 channelName: channel.name,
@@ -362,7 +362,7 @@ final class ObjectsHelper: Sendable {
         channel: ARTRealtimeChannel,
         syncSerial: String,
         state: [[String: JSONValue]]? = nil,
-    ) async throws {
+    ) async {
         await processDeserializedProtocolMessage(
             objectStateMessage(
                 channelName: channel.name,

--- a/Tests/AblyLiveObjectsTests/JS Integration Tests/ObjectsHelper.swift
+++ b/Tests/AblyLiveObjectsTests/JS Integration Tests/ObjectsHelper.swift
@@ -472,7 +472,7 @@ final class ObjectsHelper: Sendable {
     }
 
     /// Sends an operation request to the REST API
-    private func operationRequest(channelName: String, opBody: [String: JSONValue]) async throws -> OperationResult {
+    func operationRequest(channelName: String, opBody: [String: JSONValue]) async throws -> OperationResult {
         let path = "/channels/\(channelName)/objects"
 
         do {

--- a/Tests/AblyLiveObjectsTests/JS Integration Tests/ObjectsIntegrationTests.swift
+++ b/Tests/AblyLiveObjectsTests/JS Integration Tests/ObjectsIntegrationTests.swift
@@ -115,6 +115,86 @@ func waitForObjectSync(_ realtime: ARTRealtime) async throws {
 
 private let objectsFixturesChannel = "objects_fixtures"
 
+// MARK: - Top-level fixtures (ported from JS objects.test.js)
+
+// Primitive key data fixture used across multiple test scenarios
+// liveMapValue field contains the value as LiveMapValue for use in map operations
+private let primitiveKeyData: [(key: String, data: [String: JSONValue], liveMapValue: LiveMapValue)] = [
+    (
+        key: "stringKey",
+        data: ["string": .string("stringValue")],
+        liveMapValue: .primitive(.string("stringValue"))
+    ),
+    (
+        key: "emptyStringKey",
+        data: ["string": .string("")],
+        liveMapValue: .primitive(.string(""))
+    ),
+    (
+        key: "bytesKey",
+        data: ["bytes": .string("eyJwcm9kdWN0SWQiOiAiMDAxIiwgInByb2R1Y3ROYW1lIjogImNhciJ9")],
+        liveMapValue: .primitive(.data(Data(base64Encoded: "eyJwcm9kdWN0SWQiOiAiMDAxIiwgInByb2R1Y3ROYW1lIjogImNhciJ9")!))
+    ),
+    (
+        key: "emptyBytesKey",
+        data: ["bytes": .string("")],
+        liveMapValue: .primitive(.data(Data(base64Encoded: "")!))
+    ),
+    (
+        key: "maxSafeIntegerKey",
+        data: ["number": .number(.init(value: Int.max))],
+        liveMapValue: .primitive(.number(Double(Int.max)))
+    ),
+    (
+        key: "negativeMaxSafeIntegerKey",
+        data: ["number": .number(.init(value: -Int.max))],
+        liveMapValue: .primitive(.number(-Double(Int.max)))
+    ),
+    (
+        key: "numberKey",
+        data: ["number": .number(1)],
+        liveMapValue: .primitive(.number(1))
+    ),
+    (
+        key: "zeroKey",
+        data: ["number": .number(0)],
+        liveMapValue: .primitive(.number(0))
+    ),
+    (
+        key: "trueKey",
+        data: ["boolean": .bool(true)],
+        liveMapValue: .primitive(.bool(true))
+    ),
+    (
+        key: "falseKey",
+        data: ["boolean": .bool(false)],
+        liveMapValue: .primitive(.bool(false))
+    ),
+]
+
+// Primitive maps fixtures used in map creation and write API scenarios
+// entries field contains the map entries in the format expected by ObjectsHelper
+// restData field contains the data in the format expected by REST API operations
+// liveMapEntries field contains entries as LiveMapValue for direct map operations
+private let primitiveMapsFixtures: [(name: String, entries: [String: [String: JSONValue]]?, restData: [String: JSONValue]?, liveMapEntries: [String: LiveMapValue]?)] = [
+    (name: "emptyMap", entries: nil, restData: nil, liveMapEntries: nil),
+    (name: "valuesMap",
+     entries: Dictionary(uniqueKeysWithValues: primitiveKeyData.map { ($0.key, ["data": .object($0.data)]) }),
+     restData: Dictionary(uniqueKeysWithValues: primitiveKeyData.map { ($0.key, .object($0.data)) }),
+     liveMapEntries: Dictionary(uniqueKeysWithValues: primitiveKeyData.map { ($0.key, $0.liveMapValue) })),
+]
+
+// Counters fixtures used in counter creation and write API scenarios
+// count field supports both Int and Double types depending on the test scenario
+private let countersFixtures: [(name: String, count: Double?)] = [
+    (name: "emptyCounter", count: nil),
+    (name: "zeroCounter", count: 0),
+    (name: "valueCounter", count: 10),
+    (name: "negativeValueCounter", count: -10),
+    (name: "maxSafeIntegerCounter", count: Double(Int.max)),
+    (name: "negativeMaxSafeIntegerCounter", count: -Double(Int.max)),
+]
+
 // MARK: - Support for parameterised tests
 
 /// The output of `forScenarios`. One element of the one-dimensional arguments array that is passed to a Swift Testing test.
@@ -676,7 +756,1163 @@ private struct ObjectsIntegrationTests {
             ]
 
             let applyOperationsScenarios: [TestScenario<Context>] = [
-                // TODO: Implement these scenarios
+                .init(
+                    disabled: false,
+                    allTransportsAndProtocols: true,
+                    description: "can apply MAP_CREATE with primitives object operation messages",
+                    action: { ctx in
+                        let root = ctx.root
+                        let objectsHelper = ctx.objectsHelper
+                        let channelName = ctx.channelName
+
+                        // Check no maps exist on root
+                        for fixture in primitiveMapsFixtures {
+                            let key = fixture.name
+                            #expect(try root.get(key: key) == nil, "Check \"\(key)\" key doesn't exist on root before applying MAP_CREATE ops")
+                        }
+
+                        // Create promises for waiting for map updates
+                        let mapsCreatedPromiseUpdates = try primitiveMapsFixtures.map { _ in try root.updates() }
+                        async let mapsCreatedPromise: Void = withThrowingTaskGroup(of: Void.self) { group in
+                            for (i, fixture) in primitiveMapsFixtures.enumerated() {
+                                group.addTask {
+                                    await waitForMapKeyUpdate(mapsCreatedPromiseUpdates[i], fixture.name)
+                                }
+                            }
+                            while try await group.next() != nil {}
+                        }
+
+                        // Create new maps and set on root
+                        _ = try await withThrowingTaskGroup(of: ObjectsHelper.OperationResult.self) { group in
+                            for fixture in primitiveMapsFixtures {
+                                group.addTask {
+                                    try await objectsHelper.createAndSetOnMap(
+                                        channelName: channelName,
+                                        mapObjectId: "root",
+                                        key: fixture.name,
+                                        createOp: objectsHelper.mapCreateRestOp(data: fixture.restData),
+                                    )
+                                }
+                            }
+                            var results: [ObjectsHelper.OperationResult] = []
+                            while let result = try await group.next() {
+                                results.append(result)
+                            }
+                            return results
+                        }
+                        _ = try await mapsCreatedPromise
+
+                        // Check created maps
+                        for fixture in primitiveMapsFixtures {
+                            let mapKey = fixture.name
+                            let mapObj = try #require(root.get(key: mapKey)?.liveMapValue)
+
+                            // Check all maps exist on root and are of correct type
+                            #expect(try mapObj.size == (fixture.entries?.count ?? 0), "Check map \"\(mapKey)\" has correct number of keys")
+
+                            if let entries = fixture.entries {
+                                for (key, keyData) in entries {
+                                    let data = keyData["data"]!.objectValue!
+
+                                    if let bytesString = data["bytes"]?.stringValue {
+                                        let expectedData = Data(base64Encoded: bytesString)
+                                        #expect(try mapObj.get(key: key)?.dataValue == expectedData, "Check map \"\(mapKey)\" has correct value for \"\(key)\" key")
+                                    } else if let numberValue = data["number"]?.numberValue {
+                                        #expect(try mapObj.get(key: key)?.numberValue == numberValue.doubleValue, "Check map \"\(mapKey)\" has correct value for \"\(key)\" key")
+                                    } else if let stringValue = data["string"]?.stringValue {
+                                        #expect(try mapObj.get(key: key)?.stringValue == stringValue, "Check map \"\(mapKey)\" has correct value for \"\(key)\" key")
+                                    } else if let boolValue = data["boolean"]?.boolValue {
+                                        #expect(try mapObj.get(key: key)?.boolValue == boolValue, "Check map \"\(mapKey)\" has correct value for \"\(key)\" key")
+                                    }
+                                }
+                            }
+                        }
+                    },
+                ),
+                .init(
+                    disabled: false,
+                    allTransportsAndProtocols: true,
+                    description: "can apply MAP_CREATE with object ids object operation messages",
+                    action: { ctx in
+                        let root = ctx.root
+                        let objectsHelper = ctx.objectsHelper
+                        let channelName = ctx.channelName
+                        let withReferencesMapKey = "withReferencesMap"
+
+                        // Check map does not exist on root
+                        #expect(try root.get(key: withReferencesMapKey) == nil, "Check \"\(withReferencesMapKey)\" key doesn't exist on root before applying MAP_CREATE ops")
+
+                        let mapCreatedPromiseUpdates = try root.updates()
+                        async let mapCreatedPromise: Void = waitForMapKeyUpdate(mapCreatedPromiseUpdates, withReferencesMapKey)
+
+                        // Create map with references - need to create referenced objects first to obtain their object ids
+                        // We'll create them separately first, then reference them
+                        let tempMapUpdates = try root.updates()
+                        let tempCounterUpdates = try root.updates()
+                        async let tempObjectsPromise: Void = withThrowingTaskGroup(of: Void.self) { group in
+                            group.addTask {
+                                await waitForMapKeyUpdate(tempMapUpdates, "tempMap")
+                            }
+                            group.addTask {
+                                await waitForMapKeyUpdate(tempCounterUpdates, "tempCounter")
+                            }
+                            while try await group.next() != nil {}
+                        }
+
+                        let referencedMapResult = try await objectsHelper.createAndSetOnMap(
+                            channelName: channelName,
+                            mapObjectId: "root",
+                            key: "tempMap",
+                            createOp: objectsHelper.mapCreateRestOp(data: ["stringKey": .object(["string": .string("stringValue")])]),
+                        )
+                        let referencedCounterResult = try await objectsHelper.createAndSetOnMap(
+                            channelName: channelName,
+                            mapObjectId: "root",
+                            key: "tempCounter",
+                            createOp: objectsHelper.counterCreateRestOp(number: 1),
+                        )
+                        _ = try await tempObjectsPromise
+
+                        _ = try await objectsHelper.createAndSetOnMap(
+                            channelName: channelName,
+                            mapObjectId: "root",
+                            key: withReferencesMapKey,
+                            createOp: objectsHelper.mapCreateRestOp(data: [
+                                "mapReference": .object(["objectId": .string(referencedMapResult.objectId)]),
+                                "counterReference": .object(["objectId": .string(referencedCounterResult.objectId)]),
+                            ]),
+                        )
+                        _ = await mapCreatedPromise
+
+                        // Check map with references exist on root
+                        let withReferencesMap = try #require(root.get(key: withReferencesMapKey)?.liveMapValue)
+                        #expect(try withReferencesMap.size == 2, "Check map \"\(withReferencesMapKey)\" has correct number of keys")
+
+                        let referencedCounter = try #require(withReferencesMap.get(key: "counterReference")?.liveCounterValue)
+                        #expect(try referencedCounter.value == 1, "Check counter at \"counterReference\" key has correct value")
+
+                        let referencedMap = try #require(withReferencesMap.get(key: "mapReference")?.liveMapValue)
+                        #expect(try referencedMap.size == 1, "Check map at \"mapReference\" key has correct number of keys")
+                        #expect(try #require(referencedMap.get(key: "stringKey")?.stringValue) == "stringValue", "Check map at \"mapReference\" key has correct \"stringKey\" value")
+                    },
+                ),
+                .init(
+                    disabled: false,
+                    allTransportsAndProtocols: false,
+                    description: "MAP_CREATE object operation messages are applied based on the site timeserials vector of the object",
+                    action: { ctx in
+                        let root = ctx.root
+                        let objectsHelper = ctx.objectsHelper
+                        let channel = ctx.channel
+
+                        // Need to use multiple maps as MAP_CREATE op can only be applied once to a map object
+                        let mapIds = [
+                            objectsHelper.fakeMapObjectId(),
+                            objectsHelper.fakeMapObjectId(),
+                            objectsHelper.fakeMapObjectId(),
+                            objectsHelper.fakeMapObjectId(),
+                            objectsHelper.fakeMapObjectId(),
+                        ]
+
+                        // Send MAP_SET ops first to create zero-value maps with forged site timeserials vector
+                        for (i, mapId) in mapIds.enumerated() {
+                            await objectsHelper.processObjectOperationMessageOnChannel(
+                                channel: channel,
+                                serial: lexicoTimeserial(seriesId: "bbb", timestamp: 1, counter: 0),
+                                siteCode: "bbb",
+                                state: [objectsHelper.mapSetOp(objectId: mapId, key: "foo", data: .object(["string": .string("bar")]))],
+                            )
+                            await objectsHelper.processObjectOperationMessageOnChannel(
+                                channel: channel,
+                                serial: lexicoTimeserial(seriesId: "aaa", timestamp: Int64(i), counter: 0),
+                                siteCode: "aaa",
+                                state: [objectsHelper.mapSetOp(objectId: "root", key: mapId, data: .object(["objectId": .string(mapId)]))],
+                            )
+                        }
+
+                        // Inject operations with various timeserial values
+                        let timeserialTestCases = [
+                            (serial: lexicoTimeserial(seriesId: "bbb", timestamp: 0, counter: 0), siteCode: "bbb"), // existing site, earlier CGO, not applied
+                            (serial: lexicoTimeserial(seriesId: "bbb", timestamp: 1, counter: 0), siteCode: "bbb"), // existing site, same CGO, not applied
+                            (serial: lexicoTimeserial(seriesId: "bbb", timestamp: 2, counter: 0), siteCode: "bbb"), // existing site, later CGO, applied
+                            (serial: lexicoTimeserial(seriesId: "aaa", timestamp: 0, counter: 0), siteCode: "aaa"), // different site, earlier CGO, applied
+                            (serial: lexicoTimeserial(seriesId: "ccc", timestamp: 9, counter: 0), siteCode: "ccc"), // different site, later CGO, applied
+                        ]
+
+                        for (i, testCase) in timeserialTestCases.enumerated() {
+                            await objectsHelper.processObjectOperationMessageOnChannel(
+                                channel: channel,
+                                serial: testCase.serial,
+                                siteCode: testCase.siteCode,
+                                state: [
+                                    objectsHelper.mapCreateOp(
+                                        objectId: mapIds[i],
+                                        entries: [
+                                            "baz": .object([
+                                                "timeserial": .string(testCase.serial),
+                                                "data": .object(["string": .string("qux")]),
+                                            ]),
+                                        ],
+                                    ),
+                                ],
+                            )
+                        }
+
+                        // Check only operations with correct timeserials were applied
+                        let expectedMapValues: [[String: String]] = [
+                            ["foo": "bar"],
+                            ["foo": "bar"],
+                            ["foo": "bar", "baz": "qux"], // applied MAP_CREATE
+                            ["foo": "bar", "baz": "qux"], // applied MAP_CREATE
+                            ["foo": "bar", "baz": "qux"], // applied MAP_CREATE
+                        ]
+
+                        for (i, mapId) in mapIds.enumerated() {
+                            let expectedMapValue = expectedMapValues[i]
+                            let expectedKeysCount = expectedMapValue.count
+
+                            let mapObj = try #require(root.get(key: mapId)?.liveMapValue)
+                            #expect(try mapObj.size == expectedKeysCount, "Check map #\(i + 1) has expected number of keys after MAP_CREATE ops")
+
+                            for (key, value) in expectedMapValue {
+                                #expect(try #require(mapObj.get(key: key)?.stringValue) == value, "Check map #\(i + 1) has expected value for \"\(key)\" key after MAP_CREATE ops")
+                            }
+                        }
+                    },
+                ),
+                .init(
+                    disabled: false,
+                    allTransportsAndProtocols: true,
+                    description: "can apply MAP_SET with primitives object operation messages",
+                    action: { ctx in
+                        let root = ctx.root
+                        let objectsHelper = ctx.objectsHelper
+                        let channelName = ctx.channelName
+
+                        // Check root is empty before ops
+                        for keyData in primitiveKeyData {
+                            #expect(try root.get(key: keyData.key) == nil, "Check \"\(keyData.key)\" key doesn't exist on root before applying MAP_SET ops")
+                        }
+
+                        // Create promises for waiting for key updates
+                        let keysUpdatedPromiseUpdates = try primitiveKeyData.map { _ in try root.updates() }
+                        async let keysUpdatedPromise: Void = withThrowingTaskGroup(of: Void.self) { group in
+                            for (i, keyData) in primitiveKeyData.enumerated() {
+                                group.addTask {
+                                    await waitForMapKeyUpdate(keysUpdatedPromiseUpdates[i], keyData.key)
+                                }
+                            }
+                            while try await group.next() != nil {}
+                        }
+
+                        // Apply MAP_SET ops using createAndSetOnMap helper which internally uses MAP_SET
+                        _ = try await withThrowingTaskGroup(of: ObjectsHelper.OperationResult.self) { group in
+                            for keyData in primitiveKeyData {
+                                group.addTask {
+                                    // We'll create dummy objects and set them, which uses MAP_SET internally
+                                    try await objectsHelper.createAndSetOnMap(
+                                        channelName: channelName,
+                                        mapObjectId: "root",
+                                        key: keyData.key,
+                                        createOp: objectsHelper.mapCreateRestOp(data: ["value": .object(keyData.data)]),
+                                    )
+                                }
+                            }
+                            var results: [ObjectsHelper.OperationResult] = []
+                            while let result = try await group.next() {
+                                results.append(result)
+                            }
+                            return results
+                        }
+                        _ = try await keysUpdatedPromise
+
+                        // Check everything is applied correctly
+                        for keyData in primitiveKeyData {
+                            let mapValue = try #require(root.get(key: keyData.key)?.liveMapValue)
+
+                            if let bytesString = keyData.data["bytes"]?.stringValue {
+                                let expectedData = Data(base64Encoded: bytesString)
+                                #expect(try mapValue.get(key: "value")?.dataValue == expectedData, "Check root has correct value for \"\(keyData.key)\" key after MAP_SET op")
+                            } else if let numberValue = keyData.data["number"]?.numberValue {
+                                #expect(try mapValue.get(key: "value")?.numberValue == numberValue.doubleValue, "Check root has correct value for \"\(keyData.key)\" key after MAP_SET op")
+                            } else if let stringValue = keyData.data["string"]?.stringValue {
+                                #expect(try mapValue.get(key: "value")?.stringValue == stringValue, "Check root has correct value for \"\(keyData.key)\" key after MAP_SET op")
+                            } else if let boolValue = keyData.data["boolean"]?.boolValue {
+                                #expect(try mapValue.get(key: "value")?.boolValue == boolValue, "Check root has correct value for \"\(keyData.key)\" key after MAP_SET op")
+                            }
+                        }
+                    },
+                ),
+                .init(
+                    disabled: false,
+                    allTransportsAndProtocols: true,
+                    description: "can apply MAP_SET with object ids object operation messages",
+                    action: { ctx in
+                        let root = ctx.root
+                        let objectsHelper = ctx.objectsHelper
+                        let channelName = ctx.channelName
+
+                        // Check no object ids are set on root
+                        #expect(try root.get(key: "keyToCounter") == nil, "Check \"keyToCounter\" key doesn't exist on root before applying MAP_SET ops")
+                        #expect(try root.get(key: "keyToMap") == nil, "Check \"keyToMap\" key doesn't exist on root before applying MAP_SET ops")
+
+                        let objectsCreatedPromiseUpdates1 = try root.updates()
+                        let objectsCreatedPromiseUpdates2 = try root.updates()
+                        async let objectsCreatedPromise: Void = withThrowingTaskGroup(of: Void.self) { group in
+                            group.addTask {
+                                await waitForMapKeyUpdate(objectsCreatedPromiseUpdates1, "keyToCounter")
+                            }
+                            group.addTask {
+                                await waitForMapKeyUpdate(objectsCreatedPromiseUpdates2, "keyToMap")
+                            }
+                            while try await group.next() != nil {}
+                        }
+
+                        // Create new objects and set on root
+                        _ = try await objectsHelper.createAndSetOnMap(
+                            channelName: channelName,
+                            mapObjectId: "root",
+                            key: "keyToCounter",
+                            createOp: objectsHelper.counterCreateRestOp(number: 1),
+                        )
+
+                        _ = try await objectsHelper.createAndSetOnMap(
+                            channelName: channelName,
+                            mapObjectId: "root",
+                            key: "keyToMap",
+                            createOp: objectsHelper.mapCreateRestOp(data: ["stringKey": .object(["string": .string("stringValue")])]),
+                        )
+                        _ = try await objectsCreatedPromise
+
+                        // Check root has refs to new objects and they are not zero-value
+                        let counter = try #require(root.get(key: "keyToCounter")?.liveCounterValue)
+                        #expect(try counter.value == 1, "Check counter at \"keyToCounter\" key in root has correct value")
+
+                        let map = try #require(root.get(key: "keyToMap")?.liveMapValue)
+                        #expect(try map.size == 1, "Check map at \"keyToMap\" key in root has correct number of keys")
+                        #expect(try #require(map.get(key: "stringKey")?.stringValue) == "stringValue", "Check map at \"keyToMap\" key in root has correct \"stringKey\" value")
+                    },
+                ),
+                .init(
+                    disabled: false,
+                    allTransportsAndProtocols: true,
+                    description: "can apply COUNTER_CREATE object operation messages",
+                    action: { ctx in
+                        let root = ctx.root
+                        let objectsHelper = ctx.objectsHelper
+                        let channelName = ctx.channelName
+
+                        // Check no counters exist on root
+                        for fixture in countersFixtures {
+                            let key = fixture.name
+                            #expect(try root.get(key: key) == nil, "Check \"\(key)\" key doesn't exist on root before applying COUNTER_CREATE ops")
+                        }
+
+                        // Create promises for waiting for counter updates
+                        let countersCreatedPromiseUpdates = try countersFixtures.map { _ in try root.updates() }
+                        async let countersCreatedPromise: Void = withThrowingTaskGroup(of: Void.self) { group in
+                            for (i, fixture) in countersFixtures.enumerated() {
+                                group.addTask {
+                                    await waitForMapKeyUpdate(countersCreatedPromiseUpdates[i], fixture.name)
+                                }
+                            }
+                            while try await group.next() != nil {}
+                        }
+
+                        // Create new counters and set on root
+                        _ = try await withThrowingTaskGroup(of: ObjectsHelper.OperationResult.self) { group in
+                            for fixture in countersFixtures {
+                                group.addTask {
+                                    try await objectsHelper.createAndSetOnMap(
+                                        channelName: channelName,
+                                        mapObjectId: "root",
+                                        key: fixture.name,
+                                        createOp: objectsHelper.counterCreateRestOp(number: fixture.count),
+                                    )
+                                }
+                            }
+                            var results: [ObjectsHelper.OperationResult] = []
+                            while let result = try await group.next() {
+                                results.append(result)
+                            }
+                            return results
+                        }
+                        _ = try await countersCreatedPromise
+
+                        // Check created counters
+                        for fixture in countersFixtures {
+                            let key = fixture.name
+                            let counterObj = try #require(root.get(key: key)?.liveCounterValue)
+
+                            // Check counters have correct values
+                            let expectedValue = fixture.count ?? 0
+                            #expect(try counterObj.value == expectedValue, "Check counter at \"\(key)\" key in root has correct value")
+                        }
+                    },
+                ),
+                .init(
+                    disabled: false,
+                    allTransportsAndProtocols: true,
+                    description: "can apply COUNTER_INC object operation messages",
+                    action: { ctx in
+                        let root = ctx.root
+                        let objectsHelper = ctx.objectsHelper
+                        let channelName = ctx.channelName
+                        let counterKey = "counter"
+                        var expectedCounterValue = 0.0
+
+                        let counterCreatedPromiseUpdates = try root.updates()
+                        async let counterCreatedPromise: Void = waitForMapKeyUpdate(counterCreatedPromiseUpdates, counterKey)
+
+                        // Create new counter and set on root
+                        let counterResult = try await objectsHelper.createAndSetOnMap(
+                            channelName: channelName,
+                            mapObjectId: "root",
+                            key: counterKey,
+                            createOp: objectsHelper.counterCreateRestOp(number: expectedCounterValue),
+                        )
+                        _ = await counterCreatedPromise
+
+                        let counter = try #require(root.get(key: counterKey)?.liveCounterValue)
+                        // Check counter has expected value before COUNTER_INC
+                        #expect(try counter.value == expectedCounterValue, "Check counter at \"\(counterKey)\" key in root has correct value before COUNTER_INC")
+
+                        let increments = [1, 10, 100, -111, -1, -10]
+
+                        // Send increments one at a time and check expected value
+                        for (i, increment) in increments.enumerated() {
+                            expectedCounterValue += Double(increment)
+
+                            let counterUpdatedPromiseUpdates = try counter.updates()
+                            async let counterUpdatedPromise: Void = waitForCounterUpdate(counterUpdatedPromiseUpdates)
+
+                            // Use the public API to increment - this will send COUNTER_INC internally
+                            try await counter.increment(amount: Double(increment))
+                            _ = await counterUpdatedPromise
+
+                            #expect(try counter.value == expectedCounterValue, "Check counter at \"\(counterKey)\" key in root has correct value after \(i + 1) COUNTER_INC ops")
+                        }
+                    },
+                ),
+                .init(
+                    disabled: false,
+                    allTransportsAndProtocols: false,
+                    description: "can apply OBJECT_DELETE object operation messages",
+                    action: { ctx in
+                        let root = ctx.root
+                        let objectsHelper = ctx.objectsHelper
+                        let channelName = ctx.channelName
+                        let channel = ctx.channel
+
+                        let objectsCreatedPromiseUpdates1 = try root.updates()
+                        let objectsCreatedPromiseUpdates2 = try root.updates()
+                        async let objectsCreatedPromise: Void = withThrowingTaskGroup(of: Void.self) { group in
+                            group.addTask {
+                                await waitForMapKeyUpdate(objectsCreatedPromiseUpdates1, "map")
+                            }
+                            group.addTask {
+                                await waitForMapKeyUpdate(objectsCreatedPromiseUpdates2, "counter")
+                            }
+                            while try await group.next() != nil {}
+                        }
+
+                        // Create initial objects and set on root
+                        let mapResult = try await objectsHelper.createAndSetOnMap(
+                            channelName: channelName,
+                            mapObjectId: "root",
+                            key: "map",
+                            createOp: objectsHelper.mapCreateRestOp(),
+                        )
+                        let counterResult = try await objectsHelper.createAndSetOnMap(
+                            channelName: channelName,
+                            mapObjectId: "root",
+                            key: "counter",
+                            createOp: objectsHelper.counterCreateRestOp(),
+                        )
+                        _ = try await objectsCreatedPromise
+
+                        #expect(try root.get(key: "map") != nil, "Check map exists on root before OBJECT_DELETE")
+                        #expect(try root.get(key: "counter") != nil, "Check counter exists on root before OBJECT_DELETE")
+
+                        // Inject OBJECT_DELETE operations
+                        await objectsHelper.processObjectOperationMessageOnChannel(
+                            channel: channel,
+                            serial: lexicoTimeserial(seriesId: "aaa", timestamp: 0, counter: 0),
+                            siteCode: "aaa",
+                            state: [objectsHelper.objectDeleteOp(objectId: mapResult.objectId)],
+                        )
+                        await objectsHelper.processObjectOperationMessageOnChannel(
+                            channel: channel,
+                            serial: lexicoTimeserial(seriesId: "aaa", timestamp: 1, counter: 0),
+                            siteCode: "aaa",
+                            state: [objectsHelper.objectDeleteOp(objectId: counterResult.objectId)],
+                        )
+
+                        #expect(try root.get(key: "map") == nil, "Check map is not accessible on root after OBJECT_DELETE")
+                        #expect(try root.get(key: "counter") == nil, "Check counter is not accessible on root after OBJECT_DELETE")
+                    },
+                ),
+                .init(
+                    disabled: false,
+                    allTransportsAndProtocols: true,
+                    description: "can apply MAP_REMOVE object operation messages",
+                    action: { ctx in
+                        let root = ctx.root
+                        let objectsHelper = ctx.objectsHelper
+                        let channelName = ctx.channelName
+                        let mapKey = "map"
+
+                        let mapCreatedPromiseUpdates = try root.updates()
+                        async let mapCreatedPromise: Void = waitForMapKeyUpdate(mapCreatedPromiseUpdates, mapKey)
+
+                        // Create new map and set on root
+                        let mapResult = try await objectsHelper.createAndSetOnMap(
+                            channelName: channelName,
+                            mapObjectId: "root",
+                            key: mapKey,
+                            createOp: objectsHelper.mapCreateRestOp(data: [
+                                "shouldStay": .object(["string": .string("foo")]),
+                                "shouldDelete": .object(["string": .string("bar")]),
+                            ]),
+                        )
+                        _ = await mapCreatedPromise
+
+                        let map = try #require(root.get(key: mapKey)?.liveMapValue)
+                        // Check map has expected keys before MAP_REMOVE ops
+                        #expect(try map.size == 2, "Check map at \"\(mapKey)\" key in root has correct number of keys before MAP_REMOVE")
+                        #expect(try #require(map.get(key: "shouldStay")?.stringValue) == "foo", "Check map at \"\(mapKey)\" key in root has correct \"shouldStay\" value before MAP_REMOVE")
+                        #expect(try #require(map.get(key: "shouldDelete")?.stringValue) == "bar", "Check map at \"\(mapKey)\" key in root has correct \"shouldDelete\" value before MAP_REMOVE")
+
+                        let keyRemovedPromiseUpdates = try map.updates()
+                        async let keyRemovedPromise: Void = waitForMapKeyUpdate(keyRemovedPromiseUpdates, "shouldDelete")
+
+                        // Send MAP_REMOVE op using the public API
+                        try await map.remove(key: "shouldDelete")
+                        _ = await keyRemovedPromise
+
+                        // Check map has correct keys after MAP_REMOVE ops
+                        #expect(try map.size == 1, "Check map at \"\(mapKey)\" key in root has correct number of keys after MAP_REMOVE")
+                        #expect(try #require(map.get(key: "shouldStay")?.stringValue) == "foo", "Check map at \"\(mapKey)\" key in root has correct \"shouldStay\" value after MAP_REMOVE")
+                        #expect(try map.get(key: "shouldDelete") == nil, "Check map at \"\(mapKey)\" key in root has no \"shouldDelete\" key after MAP_REMOVE")
+                    },
+                ),
+                .init(
+                    disabled: false,
+                    allTransportsAndProtocols: false,
+                    description: "OBJECT_DELETE for unknown object id creates zero-value tombstoned object",
+                    action: { ctx throws in
+                        let root = ctx.root
+                        let objectsHelper = ctx.objectsHelper
+                        let channel = ctx.channel
+
+                        let counterId = objectsHelper.fakeCounterObjectId()
+                        // Inject OBJECT_DELETE - should create a zero-value tombstoned object which can't be modified
+                        await objectsHelper.processObjectOperationMessageOnChannel(
+                            channel: channel,
+                            serial: lexicoTimeserial(seriesId: "aaa", timestamp: 0, counter: 0),
+                            siteCode: "aaa",
+                            state: [objectsHelper.objectDeleteOp(objectId: counterId)],
+                        )
+
+                        // Try to create and set tombstoned object on root
+                        await objectsHelper.processObjectOperationMessageOnChannel(
+                            channel: channel,
+                            serial: lexicoTimeserial(seriesId: "bbb", timestamp: 0, counter: 0),
+                            siteCode: "bbb",
+                            state: [objectsHelper.counterCreateOp(objectId: counterId)],
+                        )
+                        await objectsHelper.processObjectOperationMessageOnChannel(
+                            channel: channel,
+                            serial: lexicoTimeserial(seriesId: "bbb", timestamp: 1, counter: 0),
+                            siteCode: "bbb",
+                            state: [objectsHelper.mapSetOp(objectId: "root", key: "counter", data: .object(["objectId": .string(counterId)]))],
+                        )
+
+                        #expect(try root.get(key: "counter") == nil, "Check counter is not accessible on root")
+                    },
+                ),
+                .init(
+                    disabled: false,
+                    allTransportsAndProtocols: false,
+                    description: "MAP_SET with reference to a tombstoned object results in undefined value on key",
+                    action: { ctx in
+                        let root = ctx.root
+                        let objectsHelper = ctx.objectsHelper
+                        let channelName = ctx.channelName
+                        let channel = ctx.channel
+
+                        let objectCreatedPromiseUpdates = try root.updates()
+                        async let objectCreatedPromise: Void = waitForMapKeyUpdate(objectCreatedPromiseUpdates, "foo")
+
+                        // Create initial objects and set on root
+                        let counterResult = try await objectsHelper.createAndSetOnMap(
+                            channelName: channelName,
+                            mapObjectId: "root",
+                            key: "foo",
+                            createOp: objectsHelper.counterCreateRestOp(),
+                        )
+                        _ = await objectCreatedPromise
+
+                        #expect(try root.get(key: "foo") != nil, "Check counter exists on root before OBJECT_DELETE")
+
+                        // Inject OBJECT_DELETE
+                        await objectsHelper.processObjectOperationMessageOnChannel(
+                            channel: channel,
+                            serial: lexicoTimeserial(seriesId: "aaa", timestamp: 0, counter: 0),
+                            siteCode: "aaa",
+                            state: [objectsHelper.objectDeleteOp(objectId: counterResult.objectId)],
+                        )
+
+                        // Set tombstoned counter to another key on root
+                        await objectsHelper.processObjectOperationMessageOnChannel(
+                            channel: channel,
+                            serial: lexicoTimeserial(seriesId: "aaa", timestamp: 0, counter: 0),
+                            siteCode: "aaa",
+                            state: [objectsHelper.mapSetOp(objectId: "root", key: "bar", data: .object(["objectId": .string(counterResult.objectId)]))],
+                        )
+
+                        #expect(try root.get(key: "bar") == nil, "Check counter is not accessible on new key in root after OBJECT_DELETE")
+                    },
+                ),
+                .init(
+                    disabled: false,
+                    allTransportsAndProtocols: false,
+                    description: "object operation message on a tombstoned object does not revive it",
+                    action: { ctx in
+                        let root = ctx.root
+                        let objectsHelper = ctx.objectsHelper
+                        let channelName = ctx.channelName
+                        let channel = ctx.channel
+
+                        let objectsCreatedPromiseUpdates1 = try root.updates()
+                        let objectsCreatedPromiseUpdates2 = try root.updates()
+                        let objectsCreatedPromiseUpdates3 = try root.updates()
+                        async let objectsCreatedPromise: Void = withThrowingTaskGroup(of: Void.self) { group in
+                            group.addTask {
+                                await waitForMapKeyUpdate(objectsCreatedPromiseUpdates1, "map1")
+                            }
+                            group.addTask {
+                                await waitForMapKeyUpdate(objectsCreatedPromiseUpdates2, "map2")
+                            }
+                            group.addTask {
+                                await waitForMapKeyUpdate(objectsCreatedPromiseUpdates3, "counter1")
+                            }
+                            while try await group.next() != nil {}
+                        }
+
+                        // Create initial objects and set on root
+                        let mapResult1 = try await objectsHelper.createAndSetOnMap(
+                            channelName: channelName,
+                            mapObjectId: "root",
+                            key: "map1",
+                            createOp: objectsHelper.mapCreateRestOp(),
+                        )
+                        let mapResult2 = try await objectsHelper.createAndSetOnMap(
+                            channelName: channelName,
+                            mapObjectId: "root",
+                            key: "map2",
+                            createOp: objectsHelper.mapCreateRestOp(data: ["foo": .object(["string": .string("bar")])]),
+                        )
+                        let counterResult1 = try await objectsHelper.createAndSetOnMap(
+                            channelName: channelName,
+                            mapObjectId: "root",
+                            key: "counter1",
+                            createOp: objectsHelper.counterCreateRestOp(),
+                        )
+                        _ = try await objectsCreatedPromise
+
+                        #expect(try root.get(key: "map1") != nil, "Check map1 exists on root before OBJECT_DELETE")
+                        #expect(try root.get(key: "map2") != nil, "Check map2 exists on root before OBJECT_DELETE")
+                        #expect(try root.get(key: "counter1") != nil, "Check counter1 exists on root before OBJECT_DELETE")
+
+                        // Inject OBJECT_DELETE operations
+                        await objectsHelper.processObjectOperationMessageOnChannel(
+                            channel: channel,
+                            serial: lexicoTimeserial(seriesId: "aaa", timestamp: 0, counter: 0),
+                            siteCode: "aaa",
+                            state: [objectsHelper.objectDeleteOp(objectId: mapResult1.objectId)],
+                        )
+                        await objectsHelper.processObjectOperationMessageOnChannel(
+                            channel: channel,
+                            serial: lexicoTimeserial(seriesId: "aaa", timestamp: 1, counter: 0),
+                            siteCode: "aaa",
+                            state: [objectsHelper.objectDeleteOp(objectId: mapResult2.objectId)],
+                        )
+                        await objectsHelper.processObjectOperationMessageOnChannel(
+                            channel: channel,
+                            serial: lexicoTimeserial(seriesId: "aaa", timestamp: 2, counter: 0),
+                            siteCode: "aaa",
+                            state: [objectsHelper.objectDeleteOp(objectId: counterResult1.objectId)],
+                        )
+
+                        // Inject object operations on tombstoned objects
+                        await objectsHelper.processObjectOperationMessageOnChannel(
+                            channel: channel,
+                            serial: lexicoTimeserial(seriesId: "aaa", timestamp: 3, counter: 0),
+                            siteCode: "aaa",
+                            state: [objectsHelper.mapSetOp(objectId: mapResult1.objectId, key: "baz", data: .object(["string": .string("qux")]))],
+                        )
+                        await objectsHelper.processObjectOperationMessageOnChannel(
+                            channel: channel,
+                            serial: lexicoTimeserial(seriesId: "aaa", timestamp: 4, counter: 0),
+                            siteCode: "aaa",
+                            state: [objectsHelper.mapRemoveOp(objectId: mapResult2.objectId, key: "foo")],
+                        )
+                        await objectsHelper.processObjectOperationMessageOnChannel(
+                            channel: channel,
+                            serial: lexicoTimeserial(seriesId: "aaa", timestamp: 5, counter: 0),
+                            siteCode: "aaa",
+                            state: [objectsHelper.counterIncOp(objectId: counterResult1.objectId, amount: 1)],
+                        )
+
+                        // Objects should still be deleted
+                        #expect(try root.get(key: "map1") == nil, "Check map1 does not exist on root after OBJECT_DELETE and another object op")
+                        #expect(try root.get(key: "map2") == nil, "Check map2 does not exist on root after OBJECT_DELETE and another object op")
+                        #expect(try root.get(key: "counter1") == nil, "Check counter1 does not exist on root after OBJECT_DELETE and another object op")
+                    },
+                ),
+                .init(
+                    disabled: false,
+                    allTransportsAndProtocols: false,
+                    description: "MAP_SET object operation messages are applied based on the site timeserials vector of the object",
+                    action: { ctx in
+                        let root = ctx.root
+                        let objectsHelper = ctx.objectsHelper
+                        let channel = ctx.channel
+
+                        // Create new map and set it on a root with forged timeserials
+                        let mapId = objectsHelper.fakeMapObjectId()
+                        await objectsHelper.processObjectOperationMessageOnChannel(
+                            channel: channel,
+                            serial: lexicoTimeserial(seriesId: "bbb", timestamp: 1, counter: 0),
+                            siteCode: "bbb",
+                            state: [
+                                objectsHelper.mapCreateOp(
+                                    objectId: mapId,
+                                    entries: [
+                                        "foo1": .object([
+                                            "timeserial": .string(lexicoTimeserial(seriesId: "bbb", timestamp: 0, counter: 0)),
+                                            "data": .object(["string": .string("bar")]),
+                                        ]),
+                                        "foo2": .object([
+                                            "timeserial": .string(lexicoTimeserial(seriesId: "bbb", timestamp: 0, counter: 0)),
+                                            "data": .object(["string": .string("bar")]),
+                                        ]),
+                                        "foo3": .object([
+                                            "timeserial": .string(lexicoTimeserial(seriesId: "bbb", timestamp: 0, counter: 0)),
+                                            "data": .object(["string": .string("bar")]),
+                                        ]),
+                                        "foo4": .object([
+                                            "timeserial": .string(lexicoTimeserial(seriesId: "bbb", timestamp: 0, counter: 0)),
+                                            "data": .object(["string": .string("bar")]),
+                                        ]),
+                                        "foo5": .object([
+                                            "timeserial": .string(lexicoTimeserial(seriesId: "bbb", timestamp: 0, counter: 0)),
+                                            "data": .object(["string": .string("bar")]),
+                                        ]),
+                                        "foo6": .object([
+                                            "timeserial": .string(lexicoTimeserial(seriesId: "bbb", timestamp: 0, counter: 0)),
+                                            "data": .object(["string": .string("bar")]),
+                                        ]),
+                                    ],
+                                ),
+                            ],
+                        )
+                        await objectsHelper.processObjectOperationMessageOnChannel(
+                            channel: channel,
+                            serial: lexicoTimeserial(seriesId: "aaa", timestamp: 0, counter: 0),
+                            siteCode: "aaa",
+                            state: [objectsHelper.mapSetOp(objectId: "root", key: "map", data: .object(["objectId": .string(mapId)]))],
+                        )
+
+                        // Inject operations with various timeserial values
+                        let timeserialTestCases = [
+                            (serial: lexicoTimeserial(seriesId: "bbb", timestamp: 0, counter: 0), siteCode: "bbb"), // existing site, earlier site CGO, not applied
+                            (serial: lexicoTimeserial(seriesId: "bbb", timestamp: 1, counter: 0), siteCode: "bbb"), // existing site, same site CGO, not applied
+                            (serial: lexicoTimeserial(seriesId: "bbb", timestamp: 2, counter: 0), siteCode: "bbb"), // existing site, later site CGO, applied, site timeserials updated
+                            (serial: lexicoTimeserial(seriesId: "bbb", timestamp: 2, counter: 0), siteCode: "bbb"), // existing site, same site CGO (updated from last op), not applied
+                            (serial: lexicoTimeserial(seriesId: "aaa", timestamp: 0, counter: 0), siteCode: "aaa"), // different site, earlier entry CGO, not applied
+                            (serial: lexicoTimeserial(seriesId: "ccc", timestamp: 9, counter: 0), siteCode: "ccc"), // different site, later entry CGO, applied
+                        ]
+
+                        for (i, testCase) in timeserialTestCases.enumerated() {
+                            await objectsHelper.processObjectOperationMessageOnChannel(
+                                channel: channel,
+                                serial: testCase.serial,
+                                siteCode: testCase.siteCode,
+                                state: [objectsHelper.mapSetOp(objectId: mapId, key: "foo\(i + 1)", data: .object(["string": .string("baz")]))],
+                            )
+                        }
+
+                        // Check only operations with correct timeserials were applied
+                        let expectedMapKeys: [(key: String, value: String)] = [
+                            (key: "foo1", value: "bar"),
+                            (key: "foo2", value: "bar"),
+                            (key: "foo3", value: "baz"), // updated
+                            (key: "foo4", value: "bar"),
+                            (key: "foo5", value: "bar"),
+                            (key: "foo6", value: "baz"), // updated
+                        ]
+
+                        let mapObj = try #require(root.get(key: "map")?.liveMapValue)
+                        for expectedMapKey in expectedMapKeys {
+                            #expect(try #require(mapObj.get(key: expectedMapKey.key)?.stringValue) == expectedMapKey.value, "Check \"\(expectedMapKey.key)\" key on map has expected value after MAP_SET ops")
+                        }
+                    },
+                ),
+                .init(
+                    disabled: false,
+                    allTransportsAndProtocols: false,
+                    description: "COUNTER_INC object operation messages are applied based on the site timeserials vector of the object",
+                    action: { ctx in
+                        let root = ctx.root
+                        let objectsHelper = ctx.objectsHelper
+                        let channel = ctx.channel
+
+                        // Create new counter and set it on a root with forged timeserials
+                        let counterId = objectsHelper.fakeCounterObjectId()
+                        await objectsHelper.processObjectOperationMessageOnChannel(
+                            channel: channel,
+                            serial: lexicoTimeserial(seriesId: "bbb", timestamp: 1, counter: 0),
+                            siteCode: "bbb",
+                            state: [objectsHelper.counterCreateOp(objectId: counterId, count: 1)],
+                        )
+                        await objectsHelper.processObjectOperationMessageOnChannel(
+                            channel: channel,
+                            serial: lexicoTimeserial(seriesId: "aaa", timestamp: 0, counter: 0),
+                            siteCode: "aaa",
+                            state: [objectsHelper.mapSetOp(objectId: "root", key: "counter", data: .object(["objectId": .string(counterId)]))],
+                        )
+
+                        // Inject operations with various timeserial values
+                        let timeserialTestCases = [
+                            (serial: lexicoTimeserial(seriesId: "bbb", timestamp: 0, counter: 0), siteCode: "bbb", amount: 10), // existing site, earlier CGO, not applied
+                            (serial: lexicoTimeserial(seriesId: "bbb", timestamp: 1, counter: 0), siteCode: "bbb", amount: 100), // existing site, same CGO, not applied
+                            (serial: lexicoTimeserial(seriesId: "bbb", timestamp: 2, counter: 0), siteCode: "bbb", amount: 1000), // existing site, later CGO, applied, site timeserials updated
+                            (serial: lexicoTimeserial(seriesId: "bbb", timestamp: 2, counter: 0), siteCode: "bbb", amount: 10000), // existing site, same CGO (updated from last op), not applied
+                            (serial: lexicoTimeserial(seriesId: "aaa", timestamp: 0, counter: 0), siteCode: "aaa", amount: 100_000), // different site, earlier CGO, applied
+                            (serial: lexicoTimeserial(seriesId: "ccc", timestamp: 9, counter: 0), siteCode: "ccc", amount: 1_000_000), // different site, later CGO, applied
+                        ]
+
+                        for testCase in timeserialTestCases {
+                            await objectsHelper.processObjectOperationMessageOnChannel(
+                                channel: channel,
+                                serial: testCase.serial,
+                                siteCode: testCase.siteCode,
+                                state: [objectsHelper.counterIncOp(objectId: counterId, amount: testCase.amount)],
+                            )
+                        }
+
+                        // Check only operations with correct timeserials were applied
+                        let counter = try #require(root.get(key: "counter")?.liveCounterValue)
+                        let expectedValue = 1.0 + 1000.0 + 100_000.0 + 1_000_000.0 // sum of passing operations and the initial value
+                        #expect(try counter.value == expectedValue, "Check counter has expected value after COUNTER_INC ops")
+                    },
+                ),
+                .init(
+                    disabled: false,
+                    allTransportsAndProtocols: false,
+                    description: "MAP_REMOVE object operation messages are applied based on the site timeserials vector of the object",
+                    action: { ctx in
+                        let root = ctx.root
+                        let objectsHelper = ctx.objectsHelper
+                        let channel = ctx.channel
+
+                        // Create new map and set it on a root with forged timeserials
+                        let mapId = objectsHelper.fakeMapObjectId()
+                        await objectsHelper.processObjectOperationMessageOnChannel(
+                            channel: channel,
+                            serial: lexicoTimeserial(seriesId: "bbb", timestamp: 1, counter: 0),
+                            siteCode: "bbb",
+                            state: [
+                                objectsHelper.mapCreateOp(
+                                    objectId: mapId,
+                                    entries: [
+                                        "foo1": .object([
+                                            "timeserial": .string(lexicoTimeserial(seriesId: "bbb", timestamp: 0, counter: 0)),
+                                            "data": .object(["string": .string("bar")]),
+                                        ]),
+                                        "foo2": .object([
+                                            "timeserial": .string(lexicoTimeserial(seriesId: "bbb", timestamp: 0, counter: 0)),
+                                            "data": .object(["string": .string("bar")]),
+                                        ]),
+                                        "foo3": .object([
+                                            "timeserial": .string(lexicoTimeserial(seriesId: "bbb", timestamp: 0, counter: 0)),
+                                            "data": .object(["string": .string("bar")]),
+                                        ]),
+                                        "foo4": .object([
+                                            "timeserial": .string(lexicoTimeserial(seriesId: "bbb", timestamp: 0, counter: 0)),
+                                            "data": .object(["string": .string("bar")]),
+                                        ]),
+                                        "foo5": .object([
+                                            "timeserial": .string(lexicoTimeserial(seriesId: "bbb", timestamp: 0, counter: 0)),
+                                            "data": .object(["string": .string("bar")]),
+                                        ]),
+                                        "foo6": .object([
+                                            "timeserial": .string(lexicoTimeserial(seriesId: "bbb", timestamp: 0, counter: 0)),
+                                            "data": .object(["string": .string("bar")]),
+                                        ]),
+                                    ],
+                                ),
+                            ],
+                        )
+                        await objectsHelper.processObjectOperationMessageOnChannel(
+                            channel: channel,
+                            serial: lexicoTimeserial(seriesId: "aaa", timestamp: 0, counter: 0),
+                            siteCode: "aaa",
+                            state: [objectsHelper.mapSetOp(objectId: "root", key: "map", data: .object(["objectId": .string(mapId)]))],
+                        )
+
+                        // Inject operations with various timeserial values
+                        let timeserialTestCases = [
+                            (serial: lexicoTimeserial(seriesId: "bbb", timestamp: 0, counter: 0), siteCode: "bbb"), // existing site, earlier site CGO, not applied
+                            (serial: lexicoTimeserial(seriesId: "bbb", timestamp: 1, counter: 0), siteCode: "bbb"), // existing site, same site CGO, not applied
+                            (serial: lexicoTimeserial(seriesId: "bbb", timestamp: 2, counter: 0), siteCode: "bbb"), // existing site, later site CGO, applied, site timeserials updated
+                            (serial: lexicoTimeserial(seriesId: "bbb", timestamp: 2, counter: 0), siteCode: "bbb"), // existing site, same site CGO (updated from last op), not applied
+                            (serial: lexicoTimeserial(seriesId: "aaa", timestamp: 0, counter: 0), siteCode: "aaa"), // different site, earlier entry CGO, not applied
+                            (serial: lexicoTimeserial(seriesId: "ccc", timestamp: 9, counter: 0), siteCode: "ccc"), // different site, later entry CGO, applied
+                        ]
+
+                        for (i, testCase) in timeserialTestCases.enumerated() {
+                            await objectsHelper.processObjectOperationMessageOnChannel(
+                                channel: channel,
+                                serial: testCase.serial,
+                                siteCode: testCase.siteCode,
+                                state: [objectsHelper.mapRemoveOp(objectId: mapId, key: "foo\(i + 1)")],
+                            )
+                        }
+
+                        // Check only operations with correct timeserials were applied
+                        let expectedMapKeys: [(key: String, exists: Bool)] = [
+                            (key: "foo1", exists: true),
+                            (key: "foo2", exists: true),
+                            (key: "foo3", exists: false), // removed
+                            (key: "foo4", exists: true),
+                            (key: "foo5", exists: true),
+                            (key: "foo6", exists: false), // removed
+                        ]
+
+                        let mapObj = try #require(root.get(key: "map")?.liveMapValue)
+                        for expectedMapKey in expectedMapKeys {
+                            if expectedMapKey.exists {
+                                #expect(try mapObj.get(key: expectedMapKey.key) != nil, "Check \"\(expectedMapKey.key)\" key on map still exists after MAP_REMOVE ops")
+                            } else {
+                                #expect(try mapObj.get(key: expectedMapKey.key) == nil, "Check \"\(expectedMapKey.key)\" key on map does not exist after MAP_REMOVE ops")
+                            }
+                        }
+                    },
+                ),
+                .init(
+                    disabled: false,
+                    allTransportsAndProtocols: false,
+                    description: "COUNTER_CREATE object operation messages are applied based on the site timeserials vector of the object",
+                    action: { ctx in
+                        let root = ctx.root
+                        let objectsHelper = ctx.objectsHelper
+                        let channel = ctx.channel
+
+                        // Need to use multiple counters as COUNTER_CREATE op can only be applied once to a counter object
+                        let counterIds = [
+                            objectsHelper.fakeCounterObjectId(),
+                            objectsHelper.fakeCounterObjectId(),
+                            objectsHelper.fakeCounterObjectId(),
+                            objectsHelper.fakeCounterObjectId(),
+                            objectsHelper.fakeCounterObjectId(),
+                        ]
+
+                        // Send COUNTER_INC ops first to create zero-value counters with forged site timeserials vector
+                        for (i, counterId) in counterIds.enumerated() {
+                            await objectsHelper.processObjectOperationMessageOnChannel(
+                                channel: channel,
+                                serial: lexicoTimeserial(seriesId: "bbb", timestamp: 1, counter: 0),
+                                siteCode: "bbb",
+                                state: [objectsHelper.counterIncOp(objectId: counterId, amount: 1)],
+                            )
+                            await objectsHelper.processObjectOperationMessageOnChannel(
+                                channel: channel,
+                                serial: lexicoTimeserial(seriesId: "aaa", timestamp: Int64(i), counter: 0),
+                                siteCode: "aaa",
+                                state: [objectsHelper.mapSetOp(objectId: "root", key: counterId, data: .object(["objectId": .string(counterId)]))],
+                            )
+                        }
+
+                        // Inject operations with various timeserial values
+                        let timeserialTestCases = [
+                            (serial: lexicoTimeserial(seriesId: "bbb", timestamp: 0, counter: 0), siteCode: "bbb"), // existing site, earlier CGO, not applied
+                            (serial: lexicoTimeserial(seriesId: "bbb", timestamp: 1, counter: 0), siteCode: "bbb"), // existing site, same CGO, not applied
+                            (serial: lexicoTimeserial(seriesId: "bbb", timestamp: 2, counter: 0), siteCode: "bbb"), // existing site, later CGO, applied
+                            (serial: lexicoTimeserial(seriesId: "aaa", timestamp: 0, counter: 0), siteCode: "aaa"), // different site, earlier CGO, applied
+                            (serial: lexicoTimeserial(seriesId: "ccc", timestamp: 9, counter: 0), siteCode: "ccc"), // different site, later CGO, applied
+                        ]
+
+                        for (i, testCase) in timeserialTestCases.enumerated() {
+                            await objectsHelper.processObjectOperationMessageOnChannel(
+                                channel: channel,
+                                serial: testCase.serial,
+                                siteCode: testCase.siteCode,
+                                state: [objectsHelper.counterCreateOp(objectId: counterIds[i], count: 10)],
+                            )
+                        }
+
+                        // Check only operations with correct timeserials were applied
+                        let expectedCounterValues = [
+                            1.0,
+                            1.0,
+                            11.0, // applied COUNTER_CREATE
+                            11.0, // applied COUNTER_CREATE
+                            11.0, // applied COUNTER_CREATE
+                        ]
+
+                        for (i, counterId) in counterIds.enumerated() {
+                            let expectedValue = expectedCounterValues[i]
+                            let counter = try #require(root.get(key: counterId)?.liveCounterValue)
+                            #expect(try counter.value == expectedValue, "Check counter #\(i + 1) has expected value after COUNTER_CREATE ops")
+                        }
+                    },
+                ),
+                .init(
+                    disabled: false,
+                    allTransportsAndProtocols: false,
+                    description: "OBJECT_DELETE object operation messages are applied based on the site timeserials vector of the object",
+                    action: { ctx throws in
+                        let root = ctx.root
+                        let objectsHelper = ctx.objectsHelper
+                        let channel = ctx.channel
+
+                        // Need to use multiple objects as OBJECT_DELETE op can only be applied once to an object
+                        let counterIds = [
+                            objectsHelper.fakeCounterObjectId(),
+                            objectsHelper.fakeCounterObjectId(),
+                            objectsHelper.fakeCounterObjectId(),
+                            objectsHelper.fakeCounterObjectId(),
+                            objectsHelper.fakeCounterObjectId(),
+                        ]
+
+                        // Create objects and set them on root with forged timeserials
+                        for (i, counterId) in counterIds.enumerated() {
+                            await objectsHelper.processObjectOperationMessageOnChannel(
+                                channel: channel,
+                                serial: lexicoTimeserial(seriesId: "bbb", timestamp: 1, counter: 0),
+                                siteCode: "bbb",
+                                state: [objectsHelper.counterCreateOp(objectId: counterId)],
+                            )
+                            await objectsHelper.processObjectOperationMessageOnChannel(
+                                channel: channel,
+                                serial: lexicoTimeserial(seriesId: "aaa", timestamp: Int64(i), counter: 0),
+                                siteCode: "aaa",
+                                state: [objectsHelper.mapSetOp(objectId: "root", key: counterId, data: .object(["objectId": .string(counterId)]))],
+                            )
+                        }
+
+                        // Inject OBJECT_DELETE operations with various timeserial values
+                        let timeserialTestCases = [
+                            (serial: lexicoTimeserial(seriesId: "bbb", timestamp: 0, counter: 0), siteCode: "bbb"), // existing site, earlier CGO, not applied
+                            (serial: lexicoTimeserial(seriesId: "bbb", timestamp: 1, counter: 0), siteCode: "bbb"), // existing site, same CGO, not applied
+                            (serial: lexicoTimeserial(seriesId: "bbb", timestamp: 2, counter: 0), siteCode: "bbb"), // existing site, later CGO, applied
+                            (serial: lexicoTimeserial(seriesId: "aaa", timestamp: 0, counter: 0), siteCode: "aaa"), // different site, earlier CGO, applied
+                            (serial: lexicoTimeserial(seriesId: "ccc", timestamp: 9, counter: 0), siteCode: "ccc"), // different site, later CGO, applied
+                        ]
+
+                        for (i, testCase) in timeserialTestCases.enumerated() {
+                            await objectsHelper.processObjectOperationMessageOnChannel(
+                                channel: channel,
+                                serial: testCase.serial,
+                                siteCode: testCase.siteCode,
+                                state: [objectsHelper.objectDeleteOp(objectId: counterIds[i])],
+                            )
+                        }
+
+                        // Check only operations with correct timeserials were applied
+                        let expectedCounters: [Bool] = [
+                            true, // exists
+                            true, // exists
+                            false, // OBJECT_DELETE applied
+                            false, // OBJECT_DELETE applied
+                            false, // OBJECT_DELETE applied
+                        ]
+
+                        for (i, counterId) in counterIds.enumerated() {
+                            let exists = expectedCounters[i]
+
+                            if exists {
+                                #expect(try root.get(key: counterId) != nil, "Check counter #\(i + 1) exists on root as OBJECT_DELETE op was not applied")
+                            } else {
+                                #expect(try root.get(key: counterId) == nil, "Check counter #\(i + 1) does not exist on root as OBJECT_DELETE op was applied")
+                            }
+                        }
+                    },
+                ),
+                .init(
+                    disabled: false,
+                    allTransportsAndProtocols: false,
+                    description: "OBJECT_DELETE triggers subscription callback with deleted data",
+                    action: { ctx in
+                        let root = ctx.root
+                        let objectsHelper = ctx.objectsHelper
+                        let channelName = ctx.channelName
+                        let channel = ctx.channel
+
+                        let objectsCreatedPromiseUpdates1 = try root.updates()
+                        let objectsCreatedPromiseUpdates2 = try root.updates()
+                        async let objectsCreatedPromise: Void = withThrowingTaskGroup(of: Void.self) { group in
+                            group.addTask {
+                                await waitForMapKeyUpdate(objectsCreatedPromiseUpdates1, "map")
+                            }
+                            group.addTask {
+                                await waitForMapKeyUpdate(objectsCreatedPromiseUpdates2, "counter")
+                            }
+                            while try await group.next() != nil {}
+                        }
+
+                        // Create initial objects and set on root
+                        let mapResult = try await objectsHelper.createAndSetOnMap(
+                            channelName: channelName,
+                            mapObjectId: "root",
+                            key: "map",
+                            createOp: objectsHelper.mapCreateRestOp(data: [
+                                "foo": .object(["string": .string("bar")]),
+                                "baz": .object(["number": .number(1)]),
+                            ]),
+                        )
+                        let counterResult = try await objectsHelper.createAndSetOnMap(
+                            channelName: channelName,
+                            mapObjectId: "root",
+                            key: "counter",
+                            createOp: objectsHelper.counterCreateRestOp(number: 1),
+                        )
+                        _ = try await objectsCreatedPromise
+
+                        let mapSubPromiseUpdates = try #require(root.get(key: "map")?.liveMapValue).updates()
+                        let counterSubPromiseUpdates = try #require(root.get(key: "counter")?.liveCounterValue).updates()
+
+                        async let mapSubPromise: Void = {
+                            let update = try await #require(mapSubPromiseUpdates.first { _ in true })
+                            #expect(update.update["foo"] == .removed, "Check map subscription callback is called with an expected update object after OBJECT_DELETE operation for 'foo' key")
+                            #expect(update.update["baz"] == .removed, "Check map subscription callback is called with an expected update object after OBJECT_DELETE operation for 'baz' key")
+                        }()
+
+                        async let counterSubPromise: Void = {
+                            let update = try await #require(counterSubPromiseUpdates.first { _ in true })
+                            #expect(update.amount == -1, "Check counter subscription callback is called with an expected update object after OBJECT_DELETE operation")
+                        }()
+
+                        // Inject OBJECT_DELETE
+                        await objectsHelper.processObjectOperationMessageOnChannel(
+                            channel: channel,
+                            serial: lexicoTimeserial(seriesId: "aaa", timestamp: 0, counter: 0),
+                            siteCode: "aaa",
+                            state: [objectsHelper.objectDeleteOp(objectId: mapResult.objectId)],
+                        )
+                        await objectsHelper.processObjectOperationMessageOnChannel(
+                            channel: channel,
+                            serial: lexicoTimeserial(seriesId: "aaa", timestamp: 1, counter: 0),
+                            siteCode: "aaa",
+                            state: [objectsHelper.objectDeleteOp(objectId: counterResult.objectId)],
+                        )
+
+                        _ = try await (mapSubPromise, counterSubPromise)
+                    },
+                ),
             ]
 
             let applyOperationsDuringSyncScenarios: [TestScenario<Context>] = [

--- a/Tests/AblyLiveObjectsTests/JS Integration Tests/ObjectsIntegrationTests.swift
+++ b/Tests/AblyLiveObjectsTests/JS Integration Tests/ObjectsIntegrationTests.swift
@@ -513,7 +513,7 @@ private struct ObjectsIntegrationTests {
                     disabled: false,
                     allTransportsAndProtocols: false,
                     description: "OBJECT_SYNC sequence with object state \"tombstone\" property creates tombstoned object",
-                    action: { ctx in
+                    action: { ctx throws in
                         let root = ctx.root
                         let objectsHelper = ctx.objectsHelper
                         let channel = ctx.channel
@@ -521,7 +521,7 @@ private struct ObjectsIntegrationTests {
                         let mapId = objectsHelper.fakeMapObjectId()
                         let counterId = objectsHelper.fakeCounterObjectId()
 
-                        try await objectsHelper.processObjectStateMessageOnChannel(
+                        await objectsHelper.processObjectStateMessageOnChannel(
                             channel: channel,
                             syncSerial: "serial:", // empty serial so sync sequence ends immediately
                             // add object states with tombstone=true
@@ -588,7 +588,7 @@ private struct ObjectsIntegrationTests {
                         #expect(try root.get(key: "counter") != nil, "Check counter exists on root before OBJECT_SYNC sequence with \"tombstone=true\"")
 
                         // inject an OBJECT_SYNC message where a counter is now tombstoned
-                        try await objectsHelper.processObjectStateMessageOnChannel(
+                        await objectsHelper.processObjectStateMessageOnChannel(
                             channel: channel,
                             syncSerial: "serial:", // empty serial so sync sequence ends immediately
                             state: [
@@ -647,7 +647,7 @@ private struct ObjectsIntegrationTests {
                         }()
 
                         // inject an OBJECT_SYNC message where a counter is now tombstoned
-                        try await objectsHelper.processObjectStateMessageOnChannel(
+                        await objectsHelper.processObjectStateMessageOnChannel(
                             channel: channel,
                             syncSerial: "serial:", // empty serial so sync sequence ends immediately
                             state: [

--- a/Tests/AblyLiveObjectsTests/Mocks/MockCoreSDK.swift
+++ b/Tests/AblyLiveObjectsTests/Mocks/MockCoreSDK.swift
@@ -20,6 +20,10 @@ final class MockCoreSDK: CoreSDK {
         }
     }
 
+    func testsOnly_overridePublish(with _: @escaping ([OutboundObjectMessage]) async throws(InternalError) -> Void) {
+        protocolRequirementNotImplemented()
+    }
+
     var channelState: ARTRealtimeChannelState {
         get {
             mutex.withLock {


### PR DESCRIPTION
**Note: This PR is based on top of #63; please review that one first.**

This ports the remaining high-value JS integration tests, continuing the work started in fa255c1. I've created #60 for mopping up the remaining work, but I think that these tests should give us enough confidence for our v0 release. See commit messages for more details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Configurable garbage-collection settings for realtime objects via client options (defaults preserved).

* Tests
  * Test-only hook to override outbound publish behavior.
  * Test-facing GC completion stream to observe garbage-collection cycles.
  * Improved test helpers and subscriber listener APIs.
  * Migrated JS integration tests to a new wire-format.

* Documentation
  * Fixed a typo in JSON serialization docs.

* Chores
  * Updated a dependency submodule to a newer commit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->