### PR TITLE
Bump iOS and tvOS version used in CI

### DIFF
--- a/Sources/BuildTool/Platform.swift
+++ b/Sources/BuildTool/Platform.swift
@@ -11,9 +11,9 @@ enum Platform: String, CaseIterable {
         case .macOS:
             .fixed(platform: "macOS")
         case .iOS:
-            .lookup(destinationPredicate: .init(runtime: "iOS-18-0", deviceType: "iPhone-16"))
+            .lookup(destinationPredicate: .init(runtime: "iOS-18-4", deviceType: "iPhone-16"))
         case .tvOS:
-            .lookup(destinationPredicate: .init(runtime: "tvOS-18-0", deviceType: "Apple-TV-4K-3rd-generation-4K"))
+            .lookup(destinationPredicate: .init(runtime: "tvOS-18-4", deviceType: "Apple-TV-4K-3rd-generation-4K"))
         }
     }
 


### PR DESCRIPTION
There don't seem to be any 18.0 devices on the GitHub runner any more (which I don't understand, because per https://github.com/actions/runner-images/blob/f469601a3a60bd8f86efd594385d21e9e72691f2/images/macos/macos-15-arm64-Readme.md#L229 there should be 🤷).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS and tvOS runtime targets used for destination selection to version 18.4, aligning with the latest simulators/SDKs.
  * No changes to public interfaces or workflows; only internal runtime version predicates were adjusted.
  * macOS configurations remain unchanged.
  * Improves compatibility with current development environments without affecting existing project settings or usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->