### PR TITLE
Fix code snippet in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,23 @@ clientOptions.plugins = [.liveObjects: AblyLiveObjects.Plugin.self]
 
 let realtime = ARTRealtime(options: clientOptions)
 
-// You can now access LiveObjects functionality via a channel's `objects` property:
-let channel = realtime.channels.get("myChannel")
+// Fetch a channel, specifying the `.objectPublish` and `.objectSubscribe` modes
+let channelOptions = ARTRealtimeChannelOptions()
+channelOptions.modes = [.objectPublish, .objectSubscribe]
+let channel = realtime.channels.get("myChannel", options: channelOptions)
+
+// Attach the channel
+try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+    channel.attach { error in
+        if let error {
+            continuation.resume(throwing: error)
+        } else {
+            continuation.resume()
+        }
+    }
+}
+
+// You can now access LiveObjects functionality via the channel's `objects` property:
 let rootObject = try await channel.objects.getRoot()
 // …and so on
 ```

--- a/Sources/AblyLiveObjects/Public/Plugin.swift
+++ b/Sources/AblyLiveObjects/Public/Plugin.swift
@@ -15,8 +15,23 @@ import ObjectiveC.NSObject
 ///
 /// let realtime = ARTRealtime(options: clientOptions)
 ///
-/// // You can now access LiveObjects functionality via a channel's `objects` property:
-/// let channel = realtime.channels.get("myChannel")
+/// // Fetch a channel, specifying the `.objectPublish` and `.objectSubscribe` modes
+/// let channelOptions = ARTRealtimeChannelOptions()
+/// channelOptions.modes = [.objectPublish, .objectSubscribe]
+/// let channel = realtime.channels.get("myChannel", options: channelOptions)
+///
+/// // Attach the channel
+/// try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+///     channel.attach { error in
+///         if let error {
+///             continuation.resume(throwing: error)
+///         } else {
+///             continuation.resume()
+///         }
+///     }
+/// }
+///
+/// // You can now access LiveObjects functionality via the channel's `objects` property:
 /// let rootObject = try await channel.objects.getRoot()
 /// // …and so on
 /// ```


### PR DESCRIPTION
Specify channel modes, and attach the channel (we will shortly be introducing an implicit attach on `getRoot` but we don't have it yet).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README and in-code sample to require explicit channel options enabling object publish/subscribe modes.
  * Showed fetching a channel with options, calling channel.attach() asynchronously, then accessing LiveObjects via channel.objects.
  * Clarified usage flow and step order for object interactions.
  * Confirmed no public API signature changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->