### PR TITLE
[ECO-5535] Remove declaration of batch API

### DIFF
--- a/Sources/AblyLiveObjects/Internal/InternalDefaultRealtimeObjects.swift
+++ b/Sources/AblyLiveObjects/Internal/InternalDefaultRealtimeObjects.swift
@@ -242,10 +242,6 @@ internal final class InternalDefaultRealtimeObjects: Sendable, LiveMapObjectPool
         try await createCounter(count: 0, coreSDK: coreSDK)
     }
 
-    internal func batch(callback _: sending BatchCallback) async throws {
-        notYetImplemented()
-    }
-
     @discardableResult
     internal func on(event _: ObjectsEvent, callback _: ObjectsEventCallback) -> any OnObjectsEventResponse {
         notYetImplemented()

--- a/Sources/AblyLiveObjects/Public/Public Proxy Objects/PublicDefaultRealtimeObjects.swift
+++ b/Sources/AblyLiveObjects/Public/Public Proxy Objects/PublicDefaultRealtimeObjects.swift
@@ -86,10 +86,6 @@ internal final class PublicDefaultRealtimeObjects: RealtimeObjects {
         )
     }
 
-    internal func batch(callback: sending BatchCallback) async throws {
-        try await proxied.batch(callback: callback)
-    }
-
     internal func on(event: ObjectsEvent, callback: @escaping ObjectsEventCallback) -> any OnObjectsEventResponse {
         proxied.on(event: event, callback: callback)
     }


### PR DESCRIPTION
**Note: This PR is based on top of #70; please review that one first.**

We have not yet implemented this and will not be doing so before our initial release. Also the API is not fully correct — as things stand, if you extract a LiveObject from a map inside the batch callback (see first example on https://ably.com/docs/liveobjects/batch) you have to use an `async` API to interact with it, which is not what we want.