### PR TITLE
Remove stray gitignore entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ DerivedData/
 .swiftpm/configuration/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
-docs-coverage-report
 # End of .gitignore created by Swift Package Manager
 
 /node_modules


### PR DESCRIPTION
The Chat gitignore that I copied in b38ce55 had a mistake (fixed in https://github.com/ably/ably-chat-swift/pull/353).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * The docs-coverage-report is no longer ignored and will now be tracked in version control. It will appear in commits, pull request diffs, and repository downloads/archives. This change affects repository contents only and does not alter application behavior, runtime performance, or the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->