### PR TITLE
Switch `JSONValue`'s `number` case back to `Double`

### DIFF
--- a/Sources/AblyLiveObjects/Utility/ExtendedJSONValue.swift
+++ b/Sources/AblyLiveObjects/Utility/ExtendedJSONValue.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-/// Like ``JSONValue``, but provides an additional case named `extra`, which allows you to support additional types of data. It's used as a common base for the implementations of ``JSONValue`` and ``WireValue``, and for converting between them.
-internal indirect enum ExtendedJSONValue<Extra> {
+/// Like ``JSONValue``, but provides a flexible `number` case and an additional case named `extra`, which allows you to support additional types of data. It's used as a common base for the implementations of ``JSONValue`` and ``WireValue``, and for converting between them.
+internal indirect enum ExtendedJSONValue<Number, Extra> {
     case object([String: Self])
     case array([Self])
     case string(String)
-    case number(NSNumber)
+    case number(Number)
     case bool(Bool)
     case null
     case extra(Extra)
@@ -17,12 +17,12 @@ internal extension ExtendedJSONValue {
     /// Creates an `ExtendedJSONValue` from an object.
     ///
     /// The rules for what `deserialized` will accept are the same as those of `JSONValue.init(jsonSerializationOutput)`, with one addition: any nonsupported values are passed to the `createExtraValue` function, and the result of this function will be used to create an `ExtendedJSONValue` of case `.extra`.
-    init(deserialized: Any, createExtraValue: (Any) -> Extra) {
+    init(deserialized: Any, createNumberValue: (NSNumber) -> Number, createExtraValue: (Any) -> Extra) {
         switch deserialized {
         case let dictionary as [String: Any]:
-            self = .object(dictionary.mapValues { .init(deserialized: $0, createExtraValue: createExtraValue) })
+            self = .object(dictionary.mapValues { .init(deserialized: $0, createNumberValue: createNumberValue, createExtraValue: createExtraValue) })
         case let array as [Any]:
-            self = .array(array.map { .init(deserialized: $0, createExtraValue: createExtraValue) })
+            self = .array(array.map { .init(deserialized: $0, createNumberValue: createNumberValue, createExtraValue: createExtraValue) })
         case let string as String:
             self = .string(string)
         case let number as NSNumber:
@@ -32,7 +32,7 @@ internal extension ExtendedJSONValue {
             } else if number === kCFBooleanFalse {
                 self = .bool(false)
             } else {
-                self = .number(number)
+                self = .number(createNumberValue(number))
             }
         case is NSNull:
             self = .null
@@ -44,16 +44,16 @@ internal extension ExtendedJSONValue {
     /// Converts an `ExtendedJSONValue` to an object.
     ///
     /// The contract for what this will return are the same as those of `JSONValue.toJSONSerializationInputElement`, with one addition: any values in the input of case `.extra` will be passed to the `serializeExtraValue` function, and the result of this function call will be inserted into the output object.
-    func serialized(serializeExtraValue: (Extra) -> Any) -> Any {
+    func serialized(serializeNumberValue: (Number) -> Any, serializeExtraValue: (Extra) -> Any) -> Any {
         switch self {
         case let .object(underlying):
-            underlying.mapValues { $0.serialized(serializeExtraValue: serializeExtraValue) }
+            underlying.mapValues { $0.serialized(serializeNumberValue: serializeNumberValue, serializeExtraValue: serializeExtraValue) }
         case let .array(underlying):
-            underlying.map { $0.serialized(serializeExtraValue: serializeExtraValue) }
+            underlying.map { $0.serialized(serializeNumberValue: serializeNumberValue, serializeExtraValue: serializeExtraValue) }
         case let .string(underlying):
             underlying
         case let .number(underlying):
-            underlying
+            serializeNumberValue(underlying)
         case let .bool(underlying):
             underlying
         case .null:
@@ -64,37 +64,30 @@ internal extension ExtendedJSONValue {
     }
 }
 
-internal extension ExtendedJSONValue where Extra == Never {
-    var serialized: Any {
-        // swiftlint:disable:next trailing_closure
-        serialized(serializeExtraValue: { _ in })
-    }
-}
-
 // MARK: - Transforming the extra data
 
 internal extension ExtendedJSONValue {
-    /// Converts this `ExtendedJSONValue<Extra>` to an `ExtendedJSONValue<NewExtra>` using a given transformation.
-    func map<NewExtra, Failure>(_ transform: @escaping (Extra) throws(Failure) -> NewExtra) throws(Failure) -> ExtendedJSONValue<NewExtra> {
+    /// Converts this `ExtendedJSONValue<Number, Extra>` to an `ExtendedJSONValue<NewNumber, NewExtra>` using given transformations.
+    func map<NewNumber, NewExtra, Failure>(number transformNumber: @escaping (Number) throws(Failure) -> NewNumber, extra transformExtra: @escaping (Extra) throws(Failure) -> NewExtra) throws(Failure) -> ExtendedJSONValue<NewNumber, NewExtra> {
         switch self {
         case let .object(underlying):
             try .object(underlying.ablyLiveObjects_mapValuesWithTypedThrow { value throws(Failure) in
-                try value.map(transform)
+                try value.map(number: transformNumber, extra: transformExtra)
             })
         case let .array(underlying):
             try .array(underlying.map { element throws(Failure) in
-                try element.map(transform)
+                try element.map(number: transformNumber, extra: transformExtra)
             })
         case let .string(underlying):
             .string(underlying)
         case let .number(underlying):
-            .number(underlying)
+            try .number(transformNumber(underlying))
         case let .bool(underlying):
             .bool(underlying)
         case .null:
             .null
         case let .extra(extra):
-            try .extra(transform(extra))
+            try .extra(transformExtra(extra))
         }
     }
 }

--- a/Tests/AblyLiveObjectsTests/JS Integration Tests/ObjectsHelper.swift
+++ b/Tests/AblyLiveObjectsTests/JS Integration Tests/ObjectsHelper.swift
@@ -451,7 +451,7 @@ final class ObjectsHelper: Sendable {
         ]
 
         if let number {
-            opBody["data"] = .object(["number": .number(NSNumber(value: number))])
+            opBody["data"] = .object(["number": .number(number)])
         }
 
         if let objectId {
@@ -467,7 +467,7 @@ final class ObjectsHelper: Sendable {
         [
             "operation": .string(Actions.counterInc.stringValue),
             "objectId": .string(objectId),
-            "data": .object(["number": .number(NSNumber(value: number))]),
+            "data": .object(["number": .number(number)]),
         ]
     }
 

--- a/Tests/AblyLiveObjectsTests/JS Integration Tests/ObjectsIntegrationTests.swift
+++ b/Tests/AblyLiveObjectsTests/JS Integration Tests/ObjectsIntegrationTests.swift
@@ -131,6 +131,9 @@ private let objectsFixturesChannel = "objects_fixtures"
 
 // MARK: - Top-level fixtures (ported from JS objects.test.js)
 
+// The value of JS's `Number.MAX_SAFE_INTEGER` — the maximum integer that a `Double` can represent exactly.
+private let maxSafeInteger = Double((1 << 53) - 1)
+
 // Primitive key data fixture used across multiple test scenarios
 // liveMapValue field contains the value as LiveMapValue for use in map operations
 private let primitiveKeyData: [(key: String, data: [String: JSONValue], liveMapValue: LiveMapValue)] = [
@@ -156,13 +159,13 @@ private let primitiveKeyData: [(key: String, data: [String: JSONValue], liveMapV
     ),
     (
         key: "maxSafeIntegerKey",
-        data: ["number": .number(.init(value: Int.max))],
-        liveMapValue: .number(Double(Int.max))
+        data: ["number": .number(maxSafeInteger)],
+        liveMapValue: .number(maxSafeInteger)
     ),
     (
         key: "negativeMaxSafeIntegerKey",
-        data: ["number": .number(.init(value: -Int.max))],
-        liveMapValue: .number(-Double(Int.max))
+        data: ["number": .number(-maxSafeInteger)],
+        liveMapValue: .number(-maxSafeInteger)
     ),
     (
         key: "numberKey",
@@ -854,7 +857,7 @@ private struct ObjectsIntegrationTests {
                                         let expectedData = Data(base64Encoded: bytesString)
                                         #expect(try mapObj.get(key: key)?.dataValue == expectedData, "Check map \"\(mapKey)\" has correct value for \"\(key)\" key")
                                     } else if let numberValue = data["number"]?.numberValue {
-                                        #expect(try mapObj.get(key: key)?.numberValue == numberValue.doubleValue, "Check map \"\(mapKey)\" has correct value for \"\(key)\" key")
+                                        #expect(try mapObj.get(key: key)?.numberValue == numberValue, "Check map \"\(mapKey)\" has correct value for \"\(key)\" key")
                                     } else if let stringValue = data["string"]?.stringValue {
                                         #expect(try mapObj.get(key: key)?.stringValue == stringValue, "Check map \"\(mapKey)\" has correct value for \"\(key)\" key")
                                     } else if let boolValue = data["boolean"]?.boolValue {
@@ -1070,7 +1073,7 @@ private struct ObjectsIntegrationTests {
                                 let expectedData = Data(base64Encoded: bytesString)
                                 #expect(try mapValue.get(key: "value")?.dataValue == expectedData, "Check root has correct value for \"\(keyData.key)\" key after MAP_SET op")
                             } else if let numberValue = keyData.data["number"]?.numberValue {
-                                #expect(try mapValue.get(key: "value")?.numberValue == numberValue.doubleValue, "Check root has correct value for \"\(keyData.key)\" key after MAP_SET op")
+                                #expect(try mapValue.get(key: "value")?.numberValue == numberValue, "Check root has correct value for \"\(keyData.key)\" key after MAP_SET op")
                             } else if let stringValue = keyData.data["string"]?.stringValue {
                                 #expect(try mapValue.get(key: "value")?.stringValue == stringValue, "Check root has correct value for \"\(keyData.key)\" key after MAP_SET op")
                             } else if let boolValue = keyData.data["boolean"]?.boolValue {
@@ -2047,7 +2050,7 @@ private struct ObjectsIntegrationTests {
                                     }
                                 } else if let numberValue = keyData.data["number"] {
                                     if case let .number(expectedNumber) = numberValue {
-                                        #expect(try #require(root.get(key: keyData.key)?.numberValue) == expectedNumber.doubleValue, "Check root has correct value for \"\(keyData.key)\" key after OBJECT_SYNC has ended and buffered operations are applied")
+                                        #expect(try #require(root.get(key: keyData.key)?.numberValue) == expectedNumber, "Check root has correct value for \"\(keyData.key)\" key after OBJECT_SYNC has ended and buffered operations are applied")
                                     }
                                 } else if let boolValue = keyData.data["boolean"] {
                                     if case let .bool(expectedBool) = boolValue {
@@ -2347,7 +2350,7 @@ private struct ObjectsIntegrationTests {
                                     }
                                 } else if let numberValue = keyData.data["number"] {
                                     if case let .number(expectedNumber) = numberValue {
-                                        #expect(try #require(root.get(key: keyData.key)?.numberValue) == expectedNumber.doubleValue, "Check root has correct value for \"\(keyData.key)\" key after OBJECT_SYNC has ended and buffered operations are applied")
+                                        #expect(try #require(root.get(key: keyData.key)?.numberValue) == expectedNumber, "Check root has correct value for \"\(keyData.key)\" key after OBJECT_SYNC has ended and buffered operations are applied")
                                     }
                                 } else if let boolValue = keyData.data["boolean"] {
                                     if case let .bool(expectedBool) = boolValue {

--- a/Tests/AblyLiveObjectsTests/ObjectCreationHelpersTests.swift
+++ b/Tests/AblyLiveObjectsTests/ObjectCreationHelpersTests.swift
@@ -65,7 +65,7 @@ struct ObjectCreationHelpersTests {
             #expect(deserializedInitialValue == [
                 "map": [
                     // RTO11f4a
-                    "semantics": .number(ObjectsMapSemantics.lww.rawValue as NSNumber),
+                    "semantics": .number(Double(ObjectsMapSemantics.lww.rawValue)),
                     "entries": [
                         // RTO11f4c1a
                         "mapRef": [


### PR DESCRIPTION
**Note: This PR is based on top of #88; please review that one first.**

This reverts the public API change of fd1e91c whilst preserving the internal MessagePack-related motivation for that commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Updated numeric representation to Double across public APIs for more consistent number handling.
  - ExtendedJSONValue now distinguishes number and extra types, with updated serialization/deserialization and mapping APIs requiring number-specific converters.
  - API changes are breaking; updates may be required in code using number values.
- Tests
  - Adjusted integration tests to use JavaScript Number.MAX_SAFE_INTEGER for cross-platform consistency.
  - Updated expectations to compare numeric values directly rather than via intermediate wrappers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->