### PR TITLE
Use server time for object ID per spec

### DIFF
--- a/AblyLiveObjects.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AblyLiveObjects.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,12 @@
 {
-  "originHash" : "a9bb12b2370d8ccfa25000a37b1301668b79689668f71059fea14431be9a0649",
+  "originHash" : "fafd5590fad90c81ba4c543a3eb57d220d0404f5b00c0fdebfcc9a899cc2ed31",
   "pins" : [
     {
       "identity" : "ably-cocoa",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ably/ably-cocoa",
       "state" : {
-        "revision" : "c28983fbdfee1327a4073620af255fd3b1b44b4c",
-        "version" : "1.2.46"
+        "revision" : "23954b55bea7fa24beaa6e43beb580d501e6b6e1"
       }
     },
     {
@@ -15,8 +14,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ably/ably-cocoa-plugin-support",
       "state" : {
-        "revision" : "8db4632b0664b7272d54f7b612ddad0a18d1758f",
-        "version" : "0.2.0"
+        "revision" : "37ad19df2cc6063c74ec88ecefc2ddf491db5ebf"
       }
     },
     {
@@ -24,8 +22,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ably/delta-codec-cocoa",
       "state" : {
-        "revision" : "3ee62ea40a63996b55818d44b3f0e56d8753be88",
-        "version" : "1.3.3"
+        "revision" : "d53eec08f9443c6160d941327a6f9d8bbb93cea2",
+        "version" : "1.3.5"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,12 @@
 {
-  "originHash" : "6b347363915d5bce46289bd7c3815b40c1d86d54160d10dced8b6a07956652e3",
+  "originHash" : "9002541995dc04fb561afebcaa1a0e9f7c094847cc52b4dcce9284d7664e81b7",
   "pins" : [
     {
       "identity" : "ably-cocoa",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ably/ably-cocoa",
       "state" : {
-        "revision" : "c28983fbdfee1327a4073620af255fd3b1b44b4c",
-        "version" : "1.2.46"
+        "revision" : "23954b55bea7fa24beaa6e43beb580d501e6b6e1"
       }
     },
     {
@@ -15,8 +14,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ably/ably-cocoa-plugin-support",
       "state" : {
-        "revision" : "8db4632b0664b7272d54f7b612ddad0a18d1758f",
-        "version" : "0.2.0"
+        "revision" : "37ad19df2cc6063c74ec88ecefc2ddf491db5ebf"
       }
     },
     {
@@ -24,8 +22,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ably/delta-codec-cocoa",
       "state" : {
-        "revision" : "3ee62ea40a63996b55818d44b3f0e56d8753be88",
-        "version" : "1.3.3"
+        "revision" : "d53eec08f9443c6160d941327a6f9d8bbb93cea2",
+        "version" : "1.3.5"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -20,12 +20,14 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/ably/ably-cocoa",
-            from: "1.2.46",
+            // TODO: Unpin before next release
+            revision: "23954b55bea7fa24beaa6e43beb580d501e6b6e1",
         ),
         .package(
             url: "https://github.com/ably/ably-cocoa-plugin-support",
             // Be sure to use `exact` here and not `from`; SPM does not have any special handling of 0.x versions and will resolve 'from: "0.2.0"' to anything less than 1.0.0.
-            exact: "0.2.0",
+            // TODO: Unpin before next release
+            revision: "37ad19df2cc6063c74ec88ecefc2ddf491db5ebf",
         ),
         .package(
             url: "https://github.com/apple/swift-argument-parser",

--- a/Tests/AblyLiveObjectsTests/InternalDefaultRealtimeObjectsTests.swift
+++ b/Tests/AblyLiveObjectsTests/InternalDefaultRealtimeObjectsTests.swift
@@ -1202,15 +1202,15 @@ struct InternalDefaultRealtimeObjectsTests {
             }
         }
 
+        // @spec RTO11f7
         // @spec RTO11g
         // @spec RTO11h3a
         // @spec RTO11h3b
         @Test
         func publishesObjectMessageAndCreatesMap() async throws {
             let internalQueue = TestFactories.createInternalQueue()
-            let clock = MockSimpleClock(currentTime: .init(timeIntervalSince1970: 1_754_042_434))
-            let realtimeObjects = InternalDefaultRealtimeObjectsTests.createDefaultRealtimeObjects(clock: clock, internalQueue: internalQueue)
-            let coreSDK = MockCoreSDK(channelState: .attached, internalQueue: internalQueue)
+            let realtimeObjects = InternalDefaultRealtimeObjectsTests.createDefaultRealtimeObjects(internalQueue: internalQueue)
+            let coreSDK = MockCoreSDK(channelState: .attached, serverTime: .init(timeIntervalSince1970: 1_754_042_434), internalQueue: internalQueue)
 
             // Track published messages
             var publishedMessages: [OutboundObjectMessage] = []
@@ -1234,8 +1234,7 @@ struct InternalDefaultRealtimeObjectsTests {
             #expect(publishedMessage.operation?.action == .known(.mapCreate))
             let objectID = try #require(publishedMessage.operation?.objectId)
             #expect(objectID.hasPrefix("map:"))
-            // TODO: This is a stopgap; change to use server time per RTO11f5 (https://github.com/ably/ably-liveobjects-swift-plugin/issues/50)
-            #expect(objectID.contains("1754042434000")) // check contains the mock clock's timestamp in milliseconds
+            #expect(objectID.contains("1754042434000")) // check contains the server timestamp in milliseconds per RTO11f7
             #expect(publishedMessage.operation?.map?.entries == [
                 "stringKey": .init(data: .init(string: "stringValue")),
             ])
@@ -1336,15 +1335,15 @@ struct InternalDefaultRealtimeObjectsTests {
                 }
             }
 
+            // @spec RTO12f5
             // @spec RTO12g
             // @spec RTO12h3a
             // @spec RTO12h3b
             @Test
             func publishesObjectMessageAndCreatesCounter() async throws {
                 let internalQueue = TestFactories.createInternalQueue()
-                let clock = MockSimpleClock(currentTime: .init(timeIntervalSince1970: 1_754_042_434))
-                let realtimeObjects = InternalDefaultRealtimeObjectsTests.createDefaultRealtimeObjects(clock: clock, internalQueue: internalQueue)
-                let coreSDK = MockCoreSDK(channelState: .attached, internalQueue: internalQueue)
+                let realtimeObjects = InternalDefaultRealtimeObjectsTests.createDefaultRealtimeObjects(internalQueue: internalQueue)
+                let coreSDK = MockCoreSDK(channelState: .attached, serverTime: .init(timeIntervalSince1970: 1_754_042_434), internalQueue: internalQueue)
 
                 // Track published messages
                 var publishedMessages: [OutboundObjectMessage] = []
@@ -1363,8 +1362,7 @@ struct InternalDefaultRealtimeObjectsTests {
                 #expect(publishedMessage.operation?.action == .known(.counterCreate))
                 let objectID = try #require(publishedMessage.operation?.objectId)
                 #expect(objectID.hasPrefix("counter:"))
-                // TODO: This is a stopgap; change to use server time per RTO11f5 (https://github.com/ably/ably-liveobjects-swift-plugin/issues/50)
-                #expect(objectID.contains("1754042434000")) // check contains the mock clock's timestamp in milliseconds
+                #expect(objectID.contains("1754042434000")) // check contains the server timestamp in milliseconds per RTO12f5
                 #expect(publishedMessage.operation?.counter?.count == 10.5)
 
                 // Verify initial value was merged per RTO12h3a

--- a/Tests/AblyLiveObjectsTests/Mocks/MockCoreSDK.swift
+++ b/Tests/AblyLiveObjectsTests/Mocks/MockCoreSDK.swift
@@ -8,9 +8,11 @@ final class MockCoreSDK: CoreSDK {
     private nonisolated(unsafe) var _publishHandler: (([OutboundObjectMessage]) async throws(ARTErrorInfo) -> Void)?
 
     private let channelStateMutex: DispatchQueueMutex<_AblyPluginSupportPrivate.RealtimeChannelState>
+    private let serverTime: Date
 
-    init(channelState: _AblyPluginSupportPrivate.RealtimeChannelState, internalQueue: DispatchQueue) {
+    init(channelState: _AblyPluginSupportPrivate.RealtimeChannelState, serverTime: Date = .init(), internalQueue: DispatchQueue) {
         channelStateMutex = DispatchQueueMutex(dispatchQueue: internalQueue, initialValue: channelState)
+        self.serverTime = serverTime
     }
 
     func publish(objectMessages: [OutboundObjectMessage]) async throws(ARTErrorInfo) {
@@ -34,5 +36,9 @@ final class MockCoreSDK: CoreSDK {
         mutex.withLock {
             _publishHandler = handler
         }
+    }
+
+    func fetchServerTime() async throws(ARTErrorInfo) -> Date {
+        serverTime
     }
 }


### PR DESCRIPTION
This was skipped in dcdb350 due to time constraints. Resolves #50.

The ably-cocoa changes are in https://github.com/ably/ably-cocoa/pull/2149.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Objects (maps, counters) now use server time for creation timestamps for consistent cross-client timestamps.
  * Added async server-time fetch capability used during object creation.

* **Tests**
  * Test suites updated to assert against server-provided timestamps.

* **Chores**
  * Updated dependency pins and package resolution metadata.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->