### PR TITLE
Use server-sent GC grace period per spec

### DIFF
--- a/AblyLiveObjects.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AblyLiveObjects.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,12 +1,12 @@
 {
-  "originHash" : "fafd5590fad90c81ba4c543a3eb57d220d0404f5b00c0fdebfcc9a899cc2ed31",
+  "originHash" : "a55a900b5d9d976e54130b801325ef9dd5d55ff1733d4e77fc8a6efe3c8a005a",
   "pins" : [
     {
       "identity" : "ably-cocoa",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ably/ably-cocoa",
       "state" : {
-        "revision" : "23954b55bea7fa24beaa6e43beb580d501e6b6e1"
+        "revision" : "25d8ef094290aed4571c878da44b9c293b9f8e85"
       }
     },
     {
@@ -14,7 +14,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ably/ably-cocoa-plugin-support",
       "state" : {
-        "revision" : "37ad19df2cc6063c74ec88ecefc2ddf491db5ebf"
+        "revision" : "c034504a5ef426f64e7b27534e86a0c547f3b1e8"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,12 +1,12 @@
 {
-  "originHash" : "9002541995dc04fb561afebcaa1a0e9f7c094847cc52b4dcce9284d7664e81b7",
+  "originHash" : "e7a81222a8751fd72c61f872a5ee9227192a1382b05fa1af8af69a6613b24fe1",
   "pins" : [
     {
       "identity" : "ably-cocoa",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ably/ably-cocoa",
       "state" : {
-        "revision" : "23954b55bea7fa24beaa6e43beb580d501e6b6e1"
+        "revision" : "25d8ef094290aed4571c878da44b9c293b9f8e85"
       }
     },
     {
@@ -14,7 +14,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ably/ably-cocoa-plugin-support",
       "state" : {
-        "revision" : "37ad19df2cc6063c74ec88ecefc2ddf491db5ebf"
+        "revision" : "c034504a5ef426f64e7b27534e86a0c547f3b1e8"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -21,13 +21,13 @@ let package = Package(
         .package(
             url: "https://github.com/ably/ably-cocoa",
             // TODO: Unpin before next release
-            revision: "23954b55bea7fa24beaa6e43beb580d501e6b6e1",
+            revision: "25d8ef094290aed4571c878da44b9c293b9f8e85",
         ),
         .package(
             url: "https://github.com/ably/ably-cocoa-plugin-support",
             // Be sure to use `exact` here and not `from`; SPM does not have any special handling of 0.x versions and will resolve 'from: "0.2.0"' to anything less than 1.0.0.
             // TODO: Unpin before next release
-            revision: "37ad19df2cc6063c74ec88ecefc2ddf491db5ebf",
+            revision: "c034504a5ef426f64e7b27534e86a0c547f3b1e8",
         ),
         .package(
             url: "https://github.com/apple/swift-argument-parser",

--- a/Sources/AblyLiveObjects/Internal/InternalDefaultRealtimeObjects.swift
+++ b/Sources/AblyLiveObjects/Internal/InternalDefaultRealtimeObjects.swift
@@ -27,10 +27,30 @@ internal final class InternalDefaultRealtimeObjects: Sendable, LiveMapObjectsPoo
         /// The default value comes from the suggestion in RTO10a.
         internal var interval: TimeInterval = 5 * 60
 
-        /// The initial RTO10b grace period for which we will retain tombstoned objects and map entries. This value may later get overridden by the `gcGracePeriod` of a `CONNECTED` `ProtocolMessage` from Realtime.
+        /// The initial RTO10b grace period for which we will retain tombstoned objects and map entries. This value may later get overridden by the `objectsGCGracePeriod` of a `CONNECTED` `ProtocolMessage` from Realtime.
         ///
         /// This default value comes from RTO10b3; can be overridden for testing.
-        internal var gracePeriod: TimeInterval = 24 * 60 * 60
+        internal var gracePeriod: GracePeriod = .dynamic(Self.defaultGracePeriod)
+
+        /// The default value from RTO10b3.
+        internal static let defaultGracePeriod: TimeInterval = 24 * 60 * 60
+
+        internal enum GracePeriod: Encodable, Hashable {
+            /// The client will always use this grace period, and will not update the grace period from the `objectsGCGracePeriod` of a `CONNECTED` `ProtocolMessage`.
+            ///
+            /// - Important: This should only be used in tests.
+            case fixed(TimeInterval)
+
+            /// The client will use this grace period, which may be subsequently updated by the `objectsGCGracePeriod` of a `CONNECTED` `ProtocolMessage`.
+            case dynamic(TimeInterval)
+
+            internal var toTimeInterval: TimeInterval {
+                switch self {
+                case let .fixed(timeInterval), let .dynamic(timeInterval):
+                    timeInterval
+                }
+            }
+        }
     }
 
     internal var testsOnly_objectsPool: ObjectsPool {
@@ -352,7 +372,7 @@ internal final class InternalDefaultRealtimeObjects: Sendable, LiveMapObjectsPoo
     internal func performGarbageCollection() {
         mutableStateMutex.withSync { mutableState in
             mutableState.objectsPool.nosync_performGarbageCollection(
-                gracePeriod: mutableState.garbageCollectionGracePeriod,
+                gracePeriod: mutableState.garbageCollectionGracePeriod.toTimeInterval,
                 clock: clock,
                 logger: logger,
                 eventsContinuation: completedGarbageCollectionEventsWithoutBufferingContinuation,
@@ -366,6 +386,29 @@ internal final class InternalDefaultRealtimeObjects: Sendable, LiveMapObjectsPoo
     /// Emits an element whenever a garbage collection cycle has completed.
     internal var testsOnly_completedGarbageCollectionEventsWithoutBuffering: AsyncStream<Void> {
         completedGarbageCollectionEventsWithoutBuffering
+    }
+
+    /// Sets the garbage collection grace period.
+    ///
+    /// Call this upon receiving a `CONNECTED` `ProtocolMessage`, per RTO10b2.
+    ///
+    /// - Note: If the `.fixed` grace period option was chosen on instantiation, this is a no-op.
+    internal func nosync_setGarbageCollectionGracePeriod(_ gracePeriod: TimeInterval) {
+        mutableStateMutex.withoutSync { mutableState in
+            switch mutableState.garbageCollectionGracePeriod {
+            case .fixed:
+                // no-op
+                break
+            case .dynamic:
+                mutableState.garbageCollectionGracePeriod = .dynamic(gracePeriod)
+            }
+        }
+    }
+
+    internal var testsOnly_gcGracePeriod: TimeInterval {
+        mutableStateMutex.withSync { mutableState in
+            mutableState.garbageCollectionGracePeriod.toTimeInterval
+        }
     }
 
     // MARK: - Testing
@@ -394,7 +437,7 @@ internal final class InternalDefaultRealtimeObjects: Sendable, LiveMapObjectsPoo
         internal var objectsEventSubscriptionStorage = SubscriptionStorage<ObjectsEvent, Void>()
 
         /// The RTO10b grace period for which we will retain tombstoned objects and map entries.
-        internal var garbageCollectionGracePeriod: TimeInterval
+        internal var garbageCollectionGracePeriod: GarbageCollectionOptions.GracePeriod
 
         /// The state that drives the emission of the `syncing` and `synced` events.
         ///

--- a/Sources/AblyLiveObjects/Public/Public Proxy Objects/PublicDefaultRealtimeObjects.swift
+++ b/Sources/AblyLiveObjects/Public/Public Proxy Objects/PublicDefaultRealtimeObjects.swift
@@ -122,4 +122,8 @@ internal final class PublicDefaultRealtimeObjects: RealtimeObjects {
     internal func testsOnly_overridePublish(with newImplementation: @escaping ([OutboundObjectMessage]) async throws(ARTErrorInfo) -> Void) {
         coreSDK.testsOnly_overridePublish(with: newImplementation)
     }
+
+    internal var testsOnly_gcGracePeriod: TimeInterval {
+        proxied.testsOnly_gcGracePeriod
+    }
 }

--- a/Tests/AblyLiveObjectsTests/Helpers/Ably+Concurrency.swift
+++ b/Tests/AblyLiveObjectsTests/Helpers/Ably+Concurrency.swift
@@ -48,3 +48,14 @@ extension ARTRestProtocol {
         }.get()
     }
 }
+
+extension ARTConnectionProtocol {
+    @discardableResult
+    func onceAsync(_ event: ARTRealtimeConnectionEvent) async -> ARTConnectionStateChange {
+        await withCheckedContinuation { continuation in
+            once(event) { stateChange in
+                continuation.resume(returning: stateChange)
+            }
+        }
+    }
+}

--- a/Tests/AblyLiveObjectsTests/JS Integration Tests/TestProxyTransport.swift
+++ b/Tests/AblyLiveObjectsTests/JS Integration Tests/TestProxyTransport.swift
@@ -404,7 +404,7 @@ class TestProxyTransport: ARTWebSocketTransport, @unchecked Sendable {
         msg.action = .connected
         msg.connectionId = "x-xxxxxxxx"
         msg.connectionKey = "xxxxxxx-xxxxxxxxxxxxxx-xxxxxxxx"
-        msg.connectionDetails = ARTConnectionDetails(clientId: clientId, connectionKey: "a8c10!t-3D0O4ejwTdvLkl-b33a8c10", maxMessageSize: 16384, maxFrameSize: 262_144, maxInboundRate: 250, connectionStateTtl: 60, serverId: "testServerId", maxIdleInterval: 15000)
+        msg.connectionDetails = ARTConnectionDetails(clientId: clientId, connectionKey: "a8c10!t-3D0O4ejwTdvLkl-b33a8c10", maxMessageSize: 16384, maxFrameSize: 262_144, maxInboundRate: 250, connectionStateTtl: 60, serverId: "testServerId", maxIdleInterval: 15000, objectsGCGracePeriod: 86_400_000)
         super.receive(msg)
     }
 }


### PR DESCRIPTION
Skipped in 2167277 due to time constraints. Integration tests copied from JS at `b2e5121`.

The ably-cocoa changes are in https://github.com/ably/ably-cocoa/pull/2150.

Resolves #32.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies for improved compatibility and performance.

* **Improvements**
  * Enhanced garbage collection grace period handling with more flexible configuration options, allowing dynamic adjustment based on connection details while maintaining sensible defaults.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->