### PR TITLE
Remove RTO15 TODO

### DIFF
--- a/AblyLiveObjects.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AblyLiveObjects.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,12 +1,12 @@
 {
-  "originHash" : "a55a900b5d9d976e54130b801325ef9dd5d55ff1733d4e77fc8a6efe3c8a005a",
+  "originHash" : "ef00c477e86ff8a8a2c0c6751d4f06cabc60f9f46c566992f1e11a699b8dad63",
   "pins" : [
     {
       "identity" : "ably-cocoa",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ably/ably-cocoa",
       "state" : {
-        "revision" : "25d8ef094290aed4571c878da44b9c293b9f8e85"
+        "revision" : "4a394311f110b9a67b372934346605740f0e7a53"
       }
     },
     {
@@ -14,7 +14,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ably/ably-cocoa-plugin-support",
       "state" : {
-        "revision" : "c034504a5ef426f64e7b27534e86a0c547f3b1e8"
+        "revision" : "9699dfefd26134a808f116d28428c230907faf27"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,12 +1,12 @@
 {
-  "originHash" : "e7a81222a8751fd72c61f872a5ee9227192a1382b05fa1af8af69a6613b24fe1",
+  "originHash" : "ca4d8571e4ac09e465effbe93e88bb953c6e5822995b2c9d37b78740cec9c8d7",
   "pins" : [
     {
       "identity" : "ably-cocoa",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ably/ably-cocoa",
       "state" : {
-        "revision" : "25d8ef094290aed4571c878da44b9c293b9f8e85"
+        "revision" : "4a394311f110b9a67b372934346605740f0e7a53"
       }
     },
     {
@@ -14,7 +14,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ably/ably-cocoa-plugin-support",
       "state" : {
-        "revision" : "c034504a5ef426f64e7b27534e86a0c547f3b1e8"
+        "revision" : "9699dfefd26134a808f116d28428c230907faf27"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -21,13 +21,13 @@ let package = Package(
         .package(
             url: "https://github.com/ably/ably-cocoa",
             // TODO: Unpin before next release
-            revision: "25d8ef094290aed4571c878da44b9c293b9f8e85",
+            revision: "4a394311f110b9a67b372934346605740f0e7a53",
         ),
         .package(
             url: "https://github.com/ably/ably-cocoa-plugin-support",
             // Be sure to use `exact` here and not `from`; SPM does not have any special handling of 0.x versions and will resolve 'from: "0.2.0"' to anything less than 1.0.0.
             // TODO: Unpin before next release
-            revision: "c034504a5ef426f64e7b27534e86a0c547f3b1e8",
+            revision: "9699dfefd26134a808f116d28428c230907faf27",
         ),
         .package(
             url: "https://github.com/apple/swift-argument-parser",

--- a/Sources/AblyLiveObjects/Internal/CoreSDK.swift
+++ b/Sources/AblyLiveObjects/Internal/CoreSDK.swift
@@ -69,7 +69,7 @@ internal final class DefaultCoreSDK: CoreSDK {
             return
         }
 
-        // TODO: Implement the full spec of RTO15 (https://github.com/ably/ably-liveobjects-swift-plugin/issues/47)
+        // TODO: Implement message size checking (https://github.com/ably/ably-liveobjects-swift-plugin/issues/13)
         try await DefaultInternalPlugin.sendObject(
             objectMessages: objectMessages,
             channel: channel,


### PR DESCRIPTION
The new versions of ably-cocoa and ably-cocoa-plugin-support give us conformance to this spec point (with the exception of message size checking, which remains deferred to #13).

See:

- https://github.com/ably/ably-cocoa-plugin-support/pull/7
- https://github.com/ably/ably-cocoa/pull/2154

Resolves #47.