### PR TITLE
Add tests for sync events

### DIFF
--- a/Sources/AblyLiveObjects/Internal/InternalDefaultRealtimeObjects.swift
+++ b/Sources/AblyLiveObjects/Internal/InternalDefaultRealtimeObjects.swift
@@ -489,8 +489,10 @@ internal final class InternalDefaultRealtimeObjects: Sendable, LiveMapObjectsPoo
 
             onChannelAttachedHasObjects = hasObjects
 
-            // We will subsequently transition to .synced either by the completion of the RTO4a OBJECT_SYNC, or by the RTO4b no-HAS_OBJECTS case below
-            transition(to: .syncing, userCallbackQueue: userCallbackQueue)
+            if hasObjects || state == .initialized {
+                // We will subsequently transition to .synced either by the completion of the RTO4a OBJECT_SYNC, or by the RTO4b no-HAS_OBJECTS case below
+                transition(to: .syncing, userCallbackQueue: userCallbackQueue)
+            }
 
             // We only care about the case where HAS_OBJECTS is not set (RTO4b); if it is set then we're going to shortly receive an OBJECT_SYNC instead (RTO4a)
             guard !hasObjects else {
@@ -521,6 +523,8 @@ internal final class InternalDefaultRealtimeObjects: Sendable, LiveMapObjectsPoo
             logger.log("handleObjectSyncProtocolMessage(objectMessages: \(LoggingUtilities.formatObjectMessagesForLogging(objectMessages)), protocolMessageChannelSerial: \(String(describing: protocolMessageChannelSerial)))", level: .debug)
 
             receivedObjectSyncProtocolMessagesContinuation.yield(objectMessages)
+
+            transition(to: .syncing, userCallbackQueue: userCallbackQueue)
 
             // If populated, this contains a full set of sync data for the channel, and should be applied to the ObjectsPool.
             let completedSyncObjectsPool: [SyncObjectsPoolEntry]?


### PR DESCRIPTION
Didn't have time to write tests for these in ad60504.

These tests are based on JS's current behaviour, which was not tested; I've implemented the equivalent tests for JS in https://github.com/ably/ably-js/pull/2121. Will use these tests as a basis for writing the spec in #80.

To get these tests to pass I've had to add two behaviours from JS that I missed in ad60504:

1. Don't always transition to `SYNCING` on `ATTACHED`
2. Transition to `SYNCING` when an `OBJECT_SYNC` is received when already `SYNCED`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed synchronization state management for real-time objects to transition more accurately based on channel conditions.
  * Improved processing of object synchronization messages for better state consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->