### PR TITLE
Release version 0.4.0

### DIFF
--- a/AblyLiveObjects.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AblyLiveObjects.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,12 +1,13 @@
 {
-  "originHash" : "95afbce8759332da020c1fee21274fc36d3a4d553a84ba74cc9c6b6a362b92af",
+  "originHash" : "882ea3086372221060f5fc4b93d0254adddc2a879699f35a91adee80d3ba15ce",
   "pins" : [
     {
       "identity" : "ably-cocoa",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ably/ably-cocoa.git",
       "state" : {
-        "revision" : "5e4cca89749ec051a57c5758412c080f049fcf42"
+        "revision" : "83bb5366b09408723446d8ba8a146938eeba829e",
+        "version" : "1.2.59"
       }
     },
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Change Log
 
+## [0.4.0](https://github.com/ably/ably-liveobjects-swift-plugin/tree/0.4.0)
+
+### Operations are now applied on acknowledgement
+
+When you call a mutation method (e.g. `map.set()`), the SDK now applies the effects of this operation to the local LiveObjects data as soon as it receives the server's acknowledgement of the operation. This is an improvement over earlier versions, in which the SDK did not apply such an operation until receiving the operation's echo.
+
+Concretely, this means that in the following example, `fetchedValue` is now guaranteed to be `myValue`:
+
+```swift
+try await map.set(key: "myKey", value: "myValue")
+let fetchedValue = try map.get(key: "myKey")
+```
+
+### Other changes
+
+These changes do not affect the plugin's public API.
+
+- Buffer operations whilst `SYNCING` per updated RTO8a (https://github.com/ably/ably-liveobjects-swift-plugin/pull/109)
+- Fix events emitted upon sync (https://github.com/ably/ably-liveobjects-swift-plugin/pull/111)
+- Support the protocol v6 `ObjectMessage` structure (https://github.com/ably/ably-liveobjects-swift-plugin/pull/114)
+- Implement new rules for discarding ops buffered during sync (https://github.com/ably/ably-liveobjects-swift-plugin/pull/121)
+- Partial object sync (https://github.com/ably/ably-liveobjects-swift-plugin/pull/117)
+- Implement `MAP_CLEAR` operation (https://github.com/ably/ably-liveobjects-swift-plugin/pull/122)
+
+**Full Changelog**: https://github.com/ably/ably-liveobjects-swift-plugin/compare/0.3.0...0.4.0
+
 ## [0.3.0](https://github.com/ably/ably-liveobjects-swift-plugin/tree/0.3.0)
 
 ## What's Changed

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,12 +1,13 @@
 {
-  "originHash" : "a99712beebe11b3d7800b25f4f287f116646da3fd909c3fe89a79fb9ec598335",
+  "originHash" : "263b1ea0fd786ff1456ebaef26e6b6baa0f018c0154cf2929eaa91abb0b54061",
   "pins" : [
     {
       "identity" : "ably-cocoa",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ably/ably-cocoa.git",
       "state" : {
-        "revision" : "5e4cca89749ec051a57c5758412c080f049fcf42"
+        "revision" : "83bb5366b09408723446d8ba8a146938eeba829e",
+        "version" : "1.2.59"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -18,10 +18,9 @@ let package = Package(
         ),
     ],
     dependencies: [
-        // TODO: Unpin before release
         .package(
             url: "https://github.com/ably/ably-cocoa.git",
-            revision: "5e4cca89749ec051a57c5758412c080f049fcf42",
+            from: "1.2.59",
         ),
         .package(
             url: "https://github.com/ably/ably-cocoa-plugin-support",


### PR DESCRIPTION
**Note: This release contains a major version bump to ably-cocoa-plugin-support and thus will follow the release process described in https://github.com/ably/ably-cocoa-plugin-support?tab=readme-ov-file#release-process-for-breaking-plugin-support-changes.** That is, we must first get this and https://github.com/ably/ably-cocoa/pull/2197 approved, then merge the ably-cocoa release, then update this release PR.

Docs PR: https://github.com/ably/docs/pull/3240

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Mutations now apply their effects to local data as soon as the server acknowledges them (before any echo), so fetched values and local state reflect confirmed changes immediately—improved responsiveness with no public API changes.
* **Documentation**
  * Added a 0.4.0 changelog entry detailing the new mutation behavior and linking the full changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->