### PR TITLE
[ECO-5658] Switch to something simpler for subscription storage

### DIFF
--- a/Sources/AblyLiveObjects/Internal/DefaultInternalEventEmitter.swift
+++ b/Sources/AblyLiveObjects/Internal/DefaultInternalEventEmitter.swift
@@ -4,114 +4,141 @@ import Foundation
 
 /// An implementation of ``InternalEventEmitter``.
 /// Conforms to the RTE specification for EventEmitter behavior.
-@MainActor
-internal class DefaultInternalEventEmitter<Event: Hashable, Data>: InternalEventEmitter {
-    // Storage for listener registrations
-    private var allEventListeners: [ListenerRegistration<MainActorEventListener<Event, Data>>] = []
-    private var namedEventListeners: [Event: [ListenerRegistration<MainActorNamedEventListener<Data>>]] = [:]
+internal final class DefaultInternalEventEmitter<Event: Hashable & Sendable, Data: Sendable>: InternalEventEmitter, Sendable {
+    private let mutableStateMutex: DispatchQueueMutex<MutableState>
+
+    internal init(internalQueue: DispatchQueue) {
+        mutableStateMutex = .init(dispatchQueue: internalQueue, initialValue: .init())
+    }
+
+    // MARK: - MutableState
+
+    private struct MutableState {
+        var allEventListeners: [ListenerRegistration<EventListener<Event, Data>>] = []
+        var namedEventListeners: [Event: [ListenerRegistration<NamedEventListener<Data>>]] = [:]
+    }
 
     // MARK: - EventEmitter conformance
 
     /// RTE3: Registers listener for all events
-    internal func on(_ listener: @escaping MainActorEventListener<Event, Data>) {
+    internal func nosync_on(_ listener: @escaping EventListener<Event, Data>) {
         let registration = ListenerRegistration(listener: listener, once: false)
-        allEventListeners.append(registration)
+        mutableStateMutex.withoutSync { state in
+            state.allEventListeners.append(registration)
+        }
     }
 
     /// RTE3: Registers listener for all events with signal
-    internal func on(signalledBy signal: SubscriptionController.Signal, _ listener: @escaping MainActorEventListener<Event, Data>) {
+    internal func nosync_on(signalledBy signal: SubscriptionController.Signal, _ listener: @escaping EventListener<Event, Data>) {
         let registration = ListenerRegistration(listener: listener, once: false)
-        allEventListeners.append(registration)
+        mutableStateMutex.withoutSync { state in
+            state.allEventListeners.append(registration)
+        }
 
-        // Register this registration with the controller so it can remove it when off() is called
-        signal.controller?.addRegistration(self, registrationId: registration.id)
+        // Register this registration with the signal so the controller can remove it when nosync_off() is called
+        signal.nosync_addRegistration(self, registrationId: registration.id)
     }
 
     /// RTE3: Registers listener for specific event
-    internal func on(_ event: Event, _ listener: @escaping MainActorNamedEventListener<Data>) {
+    internal func nosync_on(_ event: Event, _ listener: @escaping NamedEventListener<Data>) {
         let registration = ListenerRegistration(listener: listener, once: false)
-        namedEventListeners[event, default: []].append(registration)
+        mutableStateMutex.withoutSync { state in
+            state.namedEventListeners[event, default: []].append(registration)
+        }
     }
 
     /// RTE3: Registers listener for specific event with signal
-    internal func on(_ event: Event, signalledBy signal: SubscriptionController.Signal, _ listener: @escaping MainActorNamedEventListener<Data>) {
+    internal func nosync_on(_ event: Event, signalledBy signal: SubscriptionController.Signal, _ listener: @escaping NamedEventListener<Data>) {
         let registration = ListenerRegistration(listener: listener, once: false)
-        namedEventListeners[event, default: []].append(registration)
+        mutableStateMutex.withoutSync { state in
+            state.namedEventListeners[event, default: []].append(registration)
+        }
 
-        // Register this registration with the controller
-        signal.controller?.addRegistration(self, registrationId: registration.id)
+        // Register this registration with the signal so the controller can remove it when nosync_off() is called
+        signal.nosync_addRegistration(self, registrationId: registration.id)
     }
 
     /// RTE4: Registers one-time listener for all events
-    internal func once(_ listener: @escaping MainActorEventListener<Event, Data>) {
+    internal func nosync_once(_ listener: @escaping EventListener<Event, Data>) {
         let registration = ListenerRegistration(listener: listener, once: true)
-        allEventListeners.append(registration)
+        mutableStateMutex.withoutSync { state in
+            state.allEventListeners.append(registration)
+        }
     }
 
     /// RTE4: Registers one-time listener for all events with signal
-    internal func once(signalledBy signal: SubscriptionController.Signal, _ listener: @escaping MainActorEventListener<Event, Data>) {
+    internal func nosync_once(signalledBy signal: SubscriptionController.Signal, _ listener: @escaping EventListener<Event, Data>) {
         let registration = ListenerRegistration(listener: listener, once: true)
-        allEventListeners.append(registration)
+        mutableStateMutex.withoutSync { state in
+            state.allEventListeners.append(registration)
+        }
 
-        // Register this registration with the controller
-        signal.controller?.addRegistration(self, registrationId: registration.id)
+        // Register this registration with the signal so the controller can remove it when nosync_off() is called
+        signal.nosync_addRegistration(self, registrationId: registration.id)
     }
 
     /// RTE4: Registers one-time listener for specific event
-    internal func once(_ event: Event, _ listener: @escaping MainActorNamedEventListener<Data>) {
+    internal func nosync_once(_ event: Event, _ listener: @escaping NamedEventListener<Data>) {
         let registration = ListenerRegistration(listener: listener, once: true)
-        namedEventListeners[event, default: []].append(registration)
+        mutableStateMutex.withoutSync { state in
+            state.namedEventListeners[event, default: []].append(registration)
+        }
     }
 
     /// RTE4: Registers one-time listener for specific event with signal
-    internal func once(_ event: Event, signalledBy signal: SubscriptionController.Signal, _ listener: @escaping MainActorNamedEventListener<Data>) {
+    internal func nosync_once(_ event: Event, signalledBy signal: SubscriptionController.Signal, _ listener: @escaping NamedEventListener<Data>) {
         let registration = ListenerRegistration(listener: listener, once: true)
-        namedEventListeners[event, default: []].append(registration)
+        mutableStateMutex.withoutSync { state in
+            state.namedEventListeners[event, default: []].append(registration)
+        }
 
-        // Register this registration with the controller
-        signal.controller?.addRegistration(self, registrationId: registration.id)
+        // Register this registration with the signal so the controller can remove it when nosync_off() is called
+        signal.nosync_addRegistration(self, registrationId: registration.id)
     }
 
     /// RTE5: Removes all listeners
-    internal func off() {
-        allEventListeners.removeAll()
-        namedEventListeners.removeAll()
+    internal func nosync_off() {
+        mutableStateMutex.withoutSync { state in
+            state.allEventListeners.removeAll()
+            state.namedEventListeners.removeAll()
+        }
     }
 
     /// RTE5: Removes all listeners for a specific event
-    internal func off(_ event: Event) {
-        namedEventListeners.removeValue(forKey: event)
+    internal func nosync_off(_ event: Event) {
+        mutableStateMutex.withoutSync { state in
+            _ = state.namedEventListeners.removeValue(forKey: event)
+        }
     }
 
     // MARK: - InternalEventEmitter conformance
 
     /// RTE6: Emits an event, calling registered listeners
     /// RTE6a: The set of listeners must not change during emit
-    internal func emit(event: Event, data: Data) {
-        // Create snapshots to ensure RTE6a compliance - listeners called during emit don't affect this invocation
-        let allEventListenersSnapshot = allEventListeners
-        let namedEventListenersSnapshot = namedEventListeners[event] ?? []
+    internal func nosync_emit(event: Event, data: Data) {
+        // Take snapshots inside withoutSync to ensure RTE6a compliance
+        let (allSnapshot, namedSnapshot) = mutableStateMutex.withoutSync { state -> ([ListenerRegistration<EventListener<Event, Data>>], [ListenerRegistration<NamedEventListener<Data>>]) in
+            let allListeners = state.allEventListeners
+            let namedListeners = state.namedEventListeners[event] ?? []
+            return (allListeners, namedListeners)
+        }
 
-        // Collect all listener IDs that need to be removed
+        // Collect all once-listener IDs that need to be removed
         var idsToRemove: [UUID] = []
 
-        // Call all-event listeners
-        for registration in allEventListenersSnapshot {
-            // Call listener per RTE6
+        // Call all-event listeners from the snapshot (outside withoutSync to avoid exclusivity violation if a listener re-enters the emitter)
+        for registration in allSnapshot {
             registration.listener(event, data)
 
-            // Mark for removal if it was a once listener
             if registration.once {
                 idsToRemove.append(registration.id)
             }
         }
 
-        // Call named event listeners
-        for registration in namedEventListenersSnapshot {
-            // Call listener per RTE6
+        // Call named event listeners from the snapshot
+        for registration in namedSnapshot {
             registration.listener(data)
 
-            // Mark for removal if it was a once listener
             if registration.once {
                 idsToRemove.append(registration.id)
             }
@@ -119,25 +146,27 @@ internal class DefaultInternalEventEmitter<Event: Hashable, Data>: InternalEvent
 
         // Remove all once listeners in one pass
         for id in idsToRemove {
-            removeRegistration(id: id)
+            nosync_removeRegistration(id: id)
         }
     }
 
     // MARK: - Registration removal (called internally and by SubscriptionController)
 
-    internal func removeRegistration(id: UUID) {
-        // Remove from all-event listeners
-        allEventListeners.removeAll { registration in
-            registration.id == id
-        }
-
-        // Remove from named-event listeners
-        for (event, listeners) in namedEventListeners {
-            namedEventListeners[event] = listeners.filter { registration in
-                registration.id != id
+    internal func nosync_removeRegistration(id: UUID) {
+        mutableStateMutex.withoutSync { state in
+            // Remove from all-event listeners
+            state.allEventListeners.removeAll { registration in
+                registration.id == id
             }
-            if namedEventListeners[event]?.isEmpty == true {
-                namedEventListeners.removeValue(forKey: event)
+
+            // Remove from named-event listeners
+            for (event, listeners) in state.namedEventListeners {
+                state.namedEventListeners[event] = listeners.filter { registration in
+                    registration.id != id
+                }
+                if state.namedEventListeners[event]?.isEmpty == true {
+                    _ = state.namedEventListeners.removeValue(forKey: event)
+                }
             }
         }
     }

--- a/Sources/AblyLiveObjects/Internal/DefaultInternalEventEmitter.swift
+++ b/Sources/AblyLiveObjects/Internal/DefaultInternalEventEmitter.swift
@@ -1,0 +1,157 @@
+// NOTE: This file is adapted from the WIP ably-swift (taken from there at commit 98996f1).
+
+import Foundation
+
+/// An implementation of ``InternalEventEmitter``.
+/// Conforms to the RTE specification for EventEmitter behavior.
+@MainActor
+internal class DefaultInternalEventEmitter<Event: Hashable, Data>: InternalEventEmitter {
+    // Storage for listener registrations
+    private var allEventListeners: [ListenerRegistration<MainActorEventListener<Event, Data>>] = []
+    private var namedEventListeners: [Event: [ListenerRegistration<MainActorNamedEventListener<Data>>]] = [:]
+
+    // MARK: - EventEmitter conformance
+
+    /// RTE3: Registers listener for all events
+    internal func on(_ listener: @escaping MainActorEventListener<Event, Data>) {
+        let registration = ListenerRegistration(listener: listener, once: false)
+        allEventListeners.append(registration)
+    }
+
+    /// RTE3: Registers listener for all events with signal
+    internal func on(signalledBy signal: SubscriptionController.Signal, _ listener: @escaping MainActorEventListener<Event, Data>) {
+        let registration = ListenerRegistration(listener: listener, once: false)
+        allEventListeners.append(registration)
+
+        // Register this registration with the controller so it can remove it when off() is called
+        signal.controller?.addRegistration(self, registrationId: registration.id)
+    }
+
+    /// RTE3: Registers listener for specific event
+    internal func on(_ event: Event, _ listener: @escaping MainActorNamedEventListener<Data>) {
+        let registration = ListenerRegistration(listener: listener, once: false)
+        namedEventListeners[event, default: []].append(registration)
+    }
+
+    /// RTE3: Registers listener for specific event with signal
+    internal func on(_ event: Event, signalledBy signal: SubscriptionController.Signal, _ listener: @escaping MainActorNamedEventListener<Data>) {
+        let registration = ListenerRegistration(listener: listener, once: false)
+        namedEventListeners[event, default: []].append(registration)
+
+        // Register this registration with the controller
+        signal.controller?.addRegistration(self, registrationId: registration.id)
+    }
+
+    /// RTE4: Registers one-time listener for all events
+    internal func once(_ listener: @escaping MainActorEventListener<Event, Data>) {
+        let registration = ListenerRegistration(listener: listener, once: true)
+        allEventListeners.append(registration)
+    }
+
+    /// RTE4: Registers one-time listener for all events with signal
+    internal func once(signalledBy signal: SubscriptionController.Signal, _ listener: @escaping MainActorEventListener<Event, Data>) {
+        let registration = ListenerRegistration(listener: listener, once: true)
+        allEventListeners.append(registration)
+
+        // Register this registration with the controller
+        signal.controller?.addRegistration(self, registrationId: registration.id)
+    }
+
+    /// RTE4: Registers one-time listener for specific event
+    internal func once(_ event: Event, _ listener: @escaping MainActorNamedEventListener<Data>) {
+        let registration = ListenerRegistration(listener: listener, once: true)
+        namedEventListeners[event, default: []].append(registration)
+    }
+
+    /// RTE4: Registers one-time listener for specific event with signal
+    internal func once(_ event: Event, signalledBy signal: SubscriptionController.Signal, _ listener: @escaping MainActorNamedEventListener<Data>) {
+        let registration = ListenerRegistration(listener: listener, once: true)
+        namedEventListeners[event, default: []].append(registration)
+
+        // Register this registration with the controller
+        signal.controller?.addRegistration(self, registrationId: registration.id)
+    }
+
+    /// RTE5: Removes all listeners
+    internal func off() {
+        allEventListeners.removeAll()
+        namedEventListeners.removeAll()
+    }
+
+    /// RTE5: Removes all listeners for a specific event
+    internal func off(_ event: Event) {
+        namedEventListeners.removeValue(forKey: event)
+    }
+
+    // MARK: - InternalEventEmitter conformance
+
+    /// RTE6: Emits an event, calling registered listeners
+    /// RTE6a: The set of listeners must not change during emit
+    internal func emit(event: Event, data: Data) {
+        // Create snapshots to ensure RTE6a compliance - listeners called during emit don't affect this invocation
+        let allEventListenersSnapshot = allEventListeners
+        let namedEventListenersSnapshot = namedEventListeners[event] ?? []
+
+        // Collect all listener IDs that need to be removed
+        var idsToRemove: [UUID] = []
+
+        // Call all-event listeners
+        for registration in allEventListenersSnapshot {
+            // Call listener per RTE6
+            registration.listener(event, data)
+
+            // Mark for removal if it was a once listener
+            if registration.once {
+                idsToRemove.append(registration.id)
+            }
+        }
+
+        // Call named event listeners
+        for registration in namedEventListenersSnapshot {
+            // Call listener per RTE6
+            registration.listener(data)
+
+            // Mark for removal if it was a once listener
+            if registration.once {
+                idsToRemove.append(registration.id)
+            }
+        }
+
+        // Remove all once listeners in one pass
+        for id in idsToRemove {
+            removeRegistration(id: id)
+        }
+    }
+
+    // MARK: - Registration removal (called internally and by SubscriptionController)
+
+    internal func removeRegistration(id: UUID) {
+        // Remove from all-event listeners
+        allEventListeners.removeAll { registration in
+            registration.id == id
+        }
+
+        // Remove from named-event listeners
+        for (event, listeners) in namedEventListeners {
+            namedEventListeners[event] = listeners.filter { registration in
+                registration.id != id
+            }
+            if namedEventListeners[event]?.isEmpty == true {
+                namedEventListeners.removeValue(forKey: event)
+            }
+        }
+    }
+
+    // MARK: - Private Types
+
+    private struct ListenerRegistration<Listener> {
+        let id = UUID()
+        let listener: Listener
+        let once: Bool
+
+        init(listener: Listener, once: Bool) {
+            self.listener = listener
+            self.once = once
+        }
+    }
+}

--- a/Sources/AblyLiveObjects/Internal/EventEmitter.swift
+++ b/Sources/AblyLiveObjects/Internal/EventEmitter.swift
@@ -1,0 +1,109 @@
+// NOTE: This file is adapted from the WIP ably-swift (taken from there at commit 98996f1).
+
+import Foundation
+
+public typealias MainActorEventListener<Event, Data> = @MainActor (Event, Data) -> Void
+public typealias MainActorNamedEventListener<Event> = @MainActor (Event) -> Void
+
+@MainActor
+internal protocol EventEmitter<Event, Data>: AnyObject {
+    associatedtype Event
+    associatedtype Data
+    associatedtype Signal
+
+    func on(_ listener: @escaping MainActorEventListener<Event, Data>)
+    func on(signalledBy signal: Signal, _ listener: @escaping MainActorEventListener<Event, Data>)
+
+    func on(_ event: Event, _ listener: @escaping MainActorNamedEventListener<Data>)
+    func on(_ event: Event, signalledBy signal: Signal, _ listener: @escaping MainActorNamedEventListener<Data>)
+
+    func once(_ listener: @escaping MainActorEventListener<Event, Data>)
+    func once(signalledBy signal: Signal, _ listener: @escaping MainActorEventListener<Event, Data>)
+
+    func once(_ event: Event, _ listener: @escaping MainActorNamedEventListener<Data>)
+    func once(_ event: Event, signalledBy signal: Signal, _ listener: @escaping MainActorNamedEventListener<Data>)
+
+    func off()
+    func off(_ event: Event)
+}
+
+// Note: We _have_ to do something other than the off(listener:) that the IDL gives, because closures don't have identity in Swift. I've gone for this approach, instead of the return value used in chat-js and LiveObjects, because it makes it easy to unsubscribe from _within_ the closure, which happens e.g. if you want to listen for one of various state changes and then unsubscribe. The "controller" and "signal" language was taken from the AbortController used in the Web's `fetch()` API.
+
+/// A subscription controller's `signal` can be passed to `EventEmitter`'s `on` or `once` methods. If you call `off()` on the controller then the listener will no longer be called.
+///
+/// - Note: Subscription lifetime is independent of that of the controller. That is, if you relinquish all references to a controller then the listener will still be called. Only calling `off()` (on the controller or on the `EventEmitter`) will end the subscription.
+@MainActor
+public protocol SubscriptionControllerProtocol {
+    associatedtype Signal
+
+    var signal: Signal { get }
+
+    /// Cancels any subscriptions for which this controller's signal was used. The listener that was passed to `on` or `once` will not be called again.
+    ///
+    /// Calling this method will not affect any future subscriptions that use the same signal.
+    func off()
+}
+
+/// The `SubscriptionControllerProtocol` implementation used by the SDK.
+@MainActor
+public final class SubscriptionController: SubscriptionControllerProtocol {
+    public init() {
+        signal = Signal()
+        signal.controller = self
+    }
+
+    public class Signal {
+        internal let id = UUID()
+        // Store weak reference to the controller that owns this signal
+        internal weak var controller: SubscriptionController?
+    }
+
+    public let signal: Signal
+
+    // Store registrations that this controller manages
+    private var registrations: [Registration] = []
+
+    public func off() {
+        // Remove all registrations that this controller created
+        for registration in registrations {
+            registration.removeFromEmitter()
+        }
+        registrations.removeAll()
+    }
+
+    internal func addRegistration(_ emitter: DefaultInternalEventEmitter<some Hashable, some Any>, registrationId: UUID) {
+        let registration = Registration(emitter: emitter, registrationId: registrationId)
+        registrations.append(registration)
+
+        // Clean up deallocated emitters periodically
+        registrations.removeAll { registration in
+            registration.isEmitterDeallocated
+        }
+    }
+
+    // MARK: - Private Types
+
+    private struct Registration {
+        private weak var emitter: (any AnyObject)?
+        private let emitterRemoveMethod: @MainActor (UUID) -> Void
+        private let registrationId: UUID
+
+        init(emitter: DefaultInternalEventEmitter<some Hashable, some Any>, registrationId: UUID) {
+            self.emitter = emitter
+            self.registrationId = registrationId
+            // Capture the remove method to avoid protocol overhead
+            emitterRemoveMethod = { @MainActor [weak emitter] id in
+                emitter?.removeRegistration(id: id)
+            }
+        }
+
+        var isEmitterDeallocated: Bool {
+            emitter == nil
+        }
+
+        @MainActor
+        func removeFromEmitter() {
+            emitterRemoveMethod(registrationId)
+        }
+    }
+}

--- a/Sources/AblyLiveObjects/Internal/EventEmitter.swift
+++ b/Sources/AblyLiveObjects/Internal/EventEmitter.swift
@@ -2,108 +2,115 @@
 
 import Foundation
 
-public typealias MainActorEventListener<Event, Data> = @MainActor (Event, Data) -> Void
-public typealias MainActorNamedEventListener<Event> = @MainActor (Event) -> Void
+internal typealias EventListener<Event, Data> = @Sendable (Event, Data) -> Void
+internal typealias NamedEventListener<Event> = @Sendable (Event) -> Void
 
-@MainActor
 internal protocol EventEmitter<Event, Data>: AnyObject {
     associatedtype Event
     associatedtype Data
     associatedtype Signal
 
-    func on(_ listener: @escaping MainActorEventListener<Event, Data>)
-    func on(signalledBy signal: Signal, _ listener: @escaping MainActorEventListener<Event, Data>)
+    func nosync_on(_ listener: @escaping EventListener<Event, Data>)
+    func nosync_on(signalledBy signal: Signal, _ listener: @escaping EventListener<Event, Data>)
 
-    func on(_ event: Event, _ listener: @escaping MainActorNamedEventListener<Data>)
-    func on(_ event: Event, signalledBy signal: Signal, _ listener: @escaping MainActorNamedEventListener<Data>)
+    func nosync_on(_ event: Event, _ listener: @escaping NamedEventListener<Data>)
+    func nosync_on(_ event: Event, signalledBy signal: Signal, _ listener: @escaping NamedEventListener<Data>)
 
-    func once(_ listener: @escaping MainActorEventListener<Event, Data>)
-    func once(signalledBy signal: Signal, _ listener: @escaping MainActorEventListener<Event, Data>)
+    func nosync_once(_ listener: @escaping EventListener<Event, Data>)
+    func nosync_once(signalledBy signal: Signal, _ listener: @escaping EventListener<Event, Data>)
 
-    func once(_ event: Event, _ listener: @escaping MainActorNamedEventListener<Data>)
-    func once(_ event: Event, signalledBy signal: Signal, _ listener: @escaping MainActorNamedEventListener<Data>)
+    func nosync_once(_ event: Event, _ listener: @escaping NamedEventListener<Data>)
+    func nosync_once(_ event: Event, signalledBy signal: Signal, _ listener: @escaping NamedEventListener<Data>)
 
-    func off()
-    func off(_ event: Event)
+    func nosync_off()
+    func nosync_off(_ event: Event)
 }
 
 // Note: We _have_ to do something other than the off(listener:) that the IDL gives, because closures don't have identity in Swift. I've gone for this approach, instead of the return value used in chat-js and LiveObjects, because it makes it easy to unsubscribe from _within_ the closure, which happens e.g. if you want to listen for one of various state changes and then unsubscribe. The "controller" and "signal" language was taken from the AbortController used in the Web's `fetch()` API.
 
-/// A subscription controller's `signal` can be passed to `EventEmitter`'s `on` or `once` methods. If you call `off()` on the controller then the listener will no longer be called.
+/// A subscription controller's `signal` can be passed to `EventEmitter`'s `nosync_on` or `nosync_once` methods. If you call `nosync_off()` on the controller then the listener will no longer be called.
 ///
-/// - Note: Subscription lifetime is independent of that of the controller. That is, if you relinquish all references to a controller then the listener will still be called. Only calling `off()` (on the controller or on the `EventEmitter`) will end the subscription.
-@MainActor
-public protocol SubscriptionControllerProtocol {
+/// - Note: Subscription lifetime is independent of that of the controller. That is, if you relinquish all references to a controller then the listener will still be called. Only calling `nosync_off()` (on the controller or on the `EventEmitter`) will end the subscription.
+internal protocol SubscriptionControllerProtocol {
     associatedtype Signal
 
     var signal: Signal { get }
 
-    /// Cancels any subscriptions for which this controller's signal was used. The listener that was passed to `on` or `once` will not be called again.
+    /// Cancels any subscriptions for which this controller's signal was used. The listener that was passed to `nosync_on` or `nosync_once` will not be called again.
     ///
     /// Calling this method will not affect any future subscriptions that use the same signal.
-    func off()
+    func nosync_off()
 }
 
 /// The `SubscriptionControllerProtocol` implementation used by the SDK.
-@MainActor
-public final class SubscriptionController: SubscriptionControllerProtocol {
-    public init() {
-        signal = Signal()
-        signal.controller = self
+internal final class SubscriptionController: SubscriptionControllerProtocol, Sendable {
+    internal let signal: Signal
+
+    internal init(internalQueue: DispatchQueue) {
+        signal = Signal(internalQueue: internalQueue)
     }
 
-    public class Signal {
+    /// The token passed to an `EventEmitter`'s `nosync_on`/`nosync_once` methods.
+    ///
+    /// It owns the registrations created via it, so that the owning controller's `nosync_off()` can remove them. Storing them here (rather than reaching them through a back-reference to the controller) is what lets `Signal` be a genuine `Sendable` with no mutable state.
+    internal final class Signal: Sendable {
         internal let id = UUID()
-        // Store weak reference to the controller that owns this signal
-        internal weak var controller: SubscriptionController?
+
+        /// The registrations created by passing this signal to an emitter.
+        private let registrations: DispatchQueueMutex<[Registration]>
+
+        internal init(internalQueue: DispatchQueue) {
+            registrations = DispatchQueueMutex(dispatchQueue: internalQueue, initialValue: [])
+        }
+
+        internal func nosync_addRegistration(_ emitter: DefaultInternalEventEmitter<some Hashable & Sendable, some Sendable>, registrationId: UUID) {
+            registrations.withoutSync { registrations in
+                registrations.append(Registration(emitter: emitter, registrationId: registrationId))
+
+                // Clean up deallocated emitters periodically
+                registrations.removeAll { registration in
+                    registration.isEmitterDeallocated
+                }
+            }
+        }
+
+        internal func nosync_removeAllRegistrations() {
+            registrations.withoutSync { registrations in
+                // Remove all registrations that were created via this signal
+                for registration in registrations {
+                    registration.nosync_removeFromEmitter()
+                }
+                registrations.removeAll()
+            }
+        }
     }
 
-    public let signal: Signal
-
-    // Store registrations that this controller manages
-    private var registrations: [Registration] = []
-
-    public func off() {
-        // Remove all registrations that this controller created
-        for registration in registrations {
-            registration.removeFromEmitter()
-        }
-        registrations.removeAll()
-    }
-
-    internal func addRegistration(_ emitter: DefaultInternalEventEmitter<some Hashable, some Any>, registrationId: UUID) {
-        let registration = Registration(emitter: emitter, registrationId: registrationId)
-        registrations.append(registration)
-
-        // Clean up deallocated emitters periodically
-        registrations.removeAll { registration in
-            registration.isEmitterDeallocated
-        }
+    internal func nosync_off() {
+        signal.nosync_removeAllRegistrations()
     }
 
     // MARK: - Private Types
 
-    private struct Registration {
-        private weak var emitter: (any AnyObject)?
-        private let emitterRemoveMethod: @MainActor (UUID) -> Void
+    private struct Registration: Sendable {
+        private let emitter: WeakRef<any AnyObject & Sendable>
+        private let nosync_emitterRemoveMethod: @Sendable (UUID) -> Void
         private let registrationId: UUID
 
-        init(emitter: DefaultInternalEventEmitter<some Hashable, some Any>, registrationId: UUID) {
-            self.emitter = emitter
+        init(emitter: DefaultInternalEventEmitter<some Hashable & Sendable, some Sendable>, registrationId: UUID) {
+            self.emitter = .init(referenced: emitter)
             self.registrationId = registrationId
             // Capture the remove method to avoid protocol overhead
-            emitterRemoveMethod = { @MainActor [weak emitter] id in
-                emitter?.removeRegistration(id: id)
+            nosync_emitterRemoveMethod = { [weak emitter] id in
+                emitter?.nosync_removeRegistration(id: id)
             }
         }
 
         var isEmitterDeallocated: Bool {
-            emitter == nil
+            emitter.referenced == nil
         }
 
-        @MainActor
-        func removeFromEmitter() {
-            emitterRemoveMethod(registrationId)
+        func nosync_removeFromEmitter() {
+            nosync_emitterRemoveMethod(registrationId)
         }
     }
 }

--- a/Sources/AblyLiveObjects/Internal/InternalDefaultLiveCounter.swift
+++ b/Sources/AblyLiveObjects/Internal/InternalDefaultLiveCounter.swift
@@ -52,7 +52,7 @@ internal final class InternalDefaultLiveCounter: Sendable {
     ) {
         mutableStateMutex = .init(
             dispatchQueue: internalQueue,
-            initialValue: .init(liveObjectMutableState: .init(objectID: objectID), data: data),
+            initialValue: .init(liveObjectMutableState: .init(objectID: objectID, internalQueue: internalQueue), data: data),
         )
         self.logger = logger
         self.userCallbackQueue = userCallbackQueue
@@ -150,44 +150,26 @@ internal final class InternalDefaultLiveCounter: Sendable {
     @discardableResult
     internal func subscribe(listener: @escaping LiveObjectUpdateCallback<DefaultLiveCounterUpdate>, coreSDK: CoreSDK) throws(ARTErrorInfo) -> any SubscribeResponse {
         try mutableStateMutex.withSync { mutableState throws(ARTErrorInfo) in
-            // swiftlint:disable:next trailing_closure
-            try mutableState.liveObjectMutableState.nosync_subscribe(listener: listener, coreSDK: coreSDK, updateSelfLater: { [weak self] action in
-                guard let self else {
-                    return
-                }
-
-                mutableStateMutex.withSync { mutableState in
-                    action(&mutableState.liveObjectMutableState)
-                }
-            })
+            try mutableState.liveObjectMutableState.nosync_subscribe(listener: listener, coreSDK: coreSDK)
         }
     }
 
     internal func unsubscribeAll() {
         mutableStateMutex.withSync { mutableState in
-            mutableState.liveObjectMutableState.unsubscribeAll()
+            mutableState.liveObjectMutableState.nosync_unsubscribeAll()
         }
     }
 
     @discardableResult
     internal func on(event: LiveObjectLifecycleEvent, callback: @escaping LiveObjectLifecycleEventCallback) -> any OnLiveObjectLifecycleEventResponse {
         mutableStateMutex.withSync { mutableState in
-            // swiftlint:disable:next trailing_closure
-            mutableState.liveObjectMutableState.on(event: event, callback: callback, updateSelfLater: { [weak self] action in
-                guard let self else {
-                    return
-                }
-
-                mutableStateMutex.withSync { mutableState in
-                    action(&mutableState.liveObjectMutableState)
-                }
-            })
+            mutableState.liveObjectMutableState.nosync_on(event: event, callback: callback)
         }
     }
 
     internal func offAll() {
         mutableStateMutex.withSync { mutableState in
-            mutableState.liveObjectMutableState.offAll()
+            mutableState.liveObjectMutableState.nosync_offAll()
         }
     }
 
@@ -198,7 +180,7 @@ internal final class InternalDefaultLiveCounter: Sendable {
     /// This is used to instruct this counter to emit updates during an `OBJECT_SYNC`.
     internal func nosync_emit(_ update: LiveObjectUpdate<DefaultLiveCounterUpdate>) {
         mutableStateMutex.withoutSync { mutableState in
-            mutableState.liveObjectMutableState.emit(update, on: userCallbackQueue)
+            mutableState.liveObjectMutableState.nosync_emit(update, on: userCallbackQueue)
         }
     }
 
@@ -425,14 +407,14 @@ internal final class InternalDefaultLiveCounter: Sendable {
                     logger: logger,
                 )
                 // RTLC7d1a
-                liveObjectMutableState.emit(update, on: userCallbackQueue)
+                liveObjectMutableState.nosync_emit(update, on: userCallbackQueue)
                 // RTLC7d1b
                 return true
             case .known(.counterInc):
                 // RTLC7d5
                 let update = applyCounterIncOperation(operation.counterInc)
                 // RTLC7d5a
-                liveObjectMutableState.emit(update, on: userCallbackQueue)
+                liveObjectMutableState.nosync_emit(update, on: userCallbackQueue)
                 // RTLC7d5b
                 return true
             case .known(.objectDelete):
@@ -447,7 +429,7 @@ internal final class InternalDefaultLiveCounter: Sendable {
                 )
 
                 // RTLC7d4a
-                liveObjectMutableState.emit(.update(.init(amount: -dataBeforeApplyingOperation)), on: userCallbackQueue)
+                liveObjectMutableState.nosync_emit(.update(.init(amount: -dataBeforeApplyingOperation)), on: userCallbackQueue)
                 // RTLC7d4b
                 return true
             default:

--- a/Sources/AblyLiveObjects/Internal/InternalDefaultLiveMap.swift
+++ b/Sources/AblyLiveObjects/Internal/InternalDefaultLiveMap.swift
@@ -78,7 +78,7 @@ internal final class InternalDefaultLiveMap: Sendable {
     ) {
         mutableStateMutex = .init(
             dispatchQueue: internalQueue,
-            initialValue: .init(liveObjectMutableState: .init(objectID: objectID), data: data, semantics: semantics),
+            initialValue: .init(liveObjectMutableState: .init(objectID: objectID, internalQueue: internalQueue), data: data, semantics: semantics),
         )
         self.logger = logger
         self.userCallbackQueue = userCallbackQueue
@@ -232,44 +232,26 @@ internal final class InternalDefaultLiveMap: Sendable {
     @discardableResult
     internal func subscribe(listener: @escaping LiveObjectUpdateCallback<DefaultLiveMapUpdate>, coreSDK: CoreSDK) throws(ARTErrorInfo) -> any SubscribeResponse {
         try mutableStateMutex.withSync { mutableState throws(ARTErrorInfo) in
-            // swiftlint:disable:next trailing_closure
-            try mutableState.liveObjectMutableState.nosync_subscribe(listener: listener, coreSDK: coreSDK, updateSelfLater: { [weak self] action in
-                guard let self else {
-                    return
-                }
-
-                mutableStateMutex.withSync { mutableState in
-                    action(&mutableState.liveObjectMutableState)
-                }
-            })
+            try mutableState.liveObjectMutableState.nosync_subscribe(listener: listener, coreSDK: coreSDK)
         }
     }
 
     internal func unsubscribeAll() {
         mutableStateMutex.withSync { mutableState in
-            mutableState.liveObjectMutableState.unsubscribeAll()
+            mutableState.liveObjectMutableState.nosync_unsubscribeAll()
         }
     }
 
     @discardableResult
     internal func on(event: LiveObjectLifecycleEvent, callback: @escaping LiveObjectLifecycleEventCallback) -> any OnLiveObjectLifecycleEventResponse {
         mutableStateMutex.withSync { mutableState in
-            // swiftlint:disable:next trailing_closure
-            mutableState.liveObjectMutableState.on(event: event, callback: callback, updateSelfLater: { [weak self] action in
-                guard let self else {
-                    return
-                }
-
-                mutableStateMutex.withSync { mutableState in
-                    action(&mutableState.liveObjectMutableState)
-                }
-            })
+            mutableState.liveObjectMutableState.nosync_on(event: event, callback: callback)
         }
     }
 
     internal func offAll() {
         mutableStateMutex.withSync { mutableState in
-            mutableState.liveObjectMutableState.offAll()
+            mutableState.liveObjectMutableState.nosync_offAll()
         }
     }
 
@@ -280,7 +262,7 @@ internal final class InternalDefaultLiveMap: Sendable {
     /// This is used to instruct this map to emit updates during an `OBJECT_SYNC`.
     internal func nosync_emit(_ update: LiveObjectUpdate<DefaultLiveMapUpdate>) {
         mutableStateMutex.withoutSync { mutableState in
-            mutableState.liveObjectMutableState.emit(update, on: userCallbackQueue)
+            mutableState.liveObjectMutableState.nosync_emit(update, on: userCallbackQueue)
         }
     }
 
@@ -663,7 +645,7 @@ internal final class InternalDefaultLiveMap: Sendable {
                     clock: clock,
                 )
                 // RTLM15d1a
-                liveObjectMutableState.emit(update, on: userCallbackQueue)
+                liveObjectMutableState.nosync_emit(update, on: userCallbackQueue)
                 // RTLM15d1b
                 return true
             case .known(.mapSet):
@@ -688,7 +670,7 @@ internal final class InternalDefaultLiveMap: Sendable {
                     clock: clock,
                 )
                 // RTLM15d6a
-                liveObjectMutableState.emit(update, on: userCallbackQueue)
+                liveObjectMutableState.nosync_emit(update, on: userCallbackQueue)
                 // RTLM15d6b
                 return true
             case .known(.mapRemove):
@@ -705,7 +687,7 @@ internal final class InternalDefaultLiveMap: Sendable {
                     clock: clock,
                 )
                 // RTLM15d7a
-                liveObjectMutableState.emit(update, on: userCallbackQueue)
+                liveObjectMutableState.nosync_emit(update, on: userCallbackQueue)
                 // RTLM15d7b
                 return true
             case .known(.objectDelete):
@@ -720,7 +702,7 @@ internal final class InternalDefaultLiveMap: Sendable {
                 )
 
                 // RTLM15d5a
-                liveObjectMutableState.emit(.update(.init(update: dataBeforeApplyingOperation.mapValues { _ in .removed })), on: userCallbackQueue)
+                liveObjectMutableState.nosync_emit(.update(.init(update: dataBeforeApplyingOperation.mapValues { _ in .removed })), on: userCallbackQueue)
                 // RTLM15d5b
                 return true
             case .known(.mapClear):
@@ -729,7 +711,7 @@ internal final class InternalDefaultLiveMap: Sendable {
                     serial: applicableOperation.objectMessageSerial,
                 )
                 // RTLM15d8a
-                liveObjectMutableState.emit(update, on: userCallbackQueue)
+                liveObjectMutableState.nosync_emit(update, on: userCallbackQueue)
                 // RTLM15d8b
                 return true
             default:
@@ -950,7 +932,7 @@ internal final class InternalDefaultLiveMap: Sendable {
 
             // RTO4b2a
             let mapUpdate = DefaultLiveMapUpdate(update: previousData.mapValues { _ in .removed })
-            liveObjectMutableState.emit(.update(mapUpdate), on: userCallbackQueue)
+            liveObjectMutableState.nosync_emit(.update(mapUpdate), on: userCallbackQueue)
         }
 
         /// Needed for ``InternalLiveObject`` conformance.

--- a/Sources/AblyLiveObjects/Internal/InternalDefaultRealtimeObjects.swift
+++ b/Sources/AblyLiveObjects/Internal/InternalDefaultRealtimeObjects.swift
@@ -135,6 +135,7 @@ internal final class InternalDefaultRealtimeObjects: Sendable, InternalRealtimeO
                     userCallbackQueue: userCallbackQueue,
                     clock: clock,
                 ),
+                internalQueue: internalQueue,
                 garbageCollectionGracePeriod: garbageCollectionOptions.gracePeriod,
             ),
         )
@@ -322,40 +323,22 @@ internal final class InternalDefaultRealtimeObjects: Sendable, InternalRealtimeO
     @discardableResult
     internal func on(event: ObjectsEvent, callback: @escaping ObjectsEventCallback) -> any OnObjectsEventResponse {
         mutableStateMutex.withSync { mutableState in
-            // swiftlint:disable:next trailing_closure
-            mutableState.on(event: event, callback: callback, updateSelfLater: { [weak self] action in
-                guard let self else {
-                    return
-                }
-
-                mutableStateMutex.withSync { mutableState in
-                    action(&mutableState)
-                }
-            })
+            mutableState.nosync_on(event: event, callback: callback)
         }
     }
 
     /// Adds a subscriber to the ``internalObjectsEventSubscriptionStorage`` (i.e. unaffected by `offAll()`).
     @discardableResult
     internal func onInternal(event: ObjectsEvent, callback: @escaping ObjectsEventCallback) -> any OnObjectsEventResponse {
-        // TODO: Looking at this again later the whole process for adding a subscriber is really verbose and boilerplate-y, and I think the unfortunate result of me trying to be clever at some point; revisit in https://github.com/ably/ably-liveobjects-swift-plugin/issues/102
+        // TODO: make the RTO20 wait-for-synced use this mechanism (https://github.com/ably/ably-liveobjects-swift-plugin/issues/120)
         mutableStateMutex.withSync { mutableState in
-            // swiftlint:disable:next trailing_closure
-            mutableState.onInternal(event: event, callback: callback, updateSelfLater: { [weak self] action in
-                guard let self else {
-                    return
-                }
-
-                mutableStateMutex.withSync { mutableState in
-                    action(&mutableState)
-                }
-            })
+            mutableState.nosync_onInternal(event: event, callback: callback)
         }
     }
 
     internal func offAll() {
         mutableStateMutex.withSync { mutableState in
-            mutableState.offAll()
+            mutableState.nosync_offAll()
         }
     }
 
@@ -643,10 +626,10 @@ internal final class InternalDefaultRealtimeObjects: Sendable, InternalRealtimeO
     private struct MutableState {
         internal var objectsPool: ObjectsPool
         internal var onChannelAttachedHasObjects: Bool?
-        internal var objectsEventSubscriptionStorage = SubscriptionStorage<ObjectsEvent, Void>()
+        internal let objectsEventSubscriptionStorage: SubscriptionStorage<ObjectsEvent, Void>
 
         /// Used when the object wishes to subscribe to its own events (i.e. unaffected by `offAll()`); used e.g. to wait for a sync before returning from `getRoot()`, per RTO1c.
-        internal var internalObjectsEventSubscriptionStorage = SubscriptionStorage<ObjectsEvent, Void>()
+        internal let internalObjectsEventSubscriptionStorage: SubscriptionStorage<ObjectsEvent, Void>
 
         /// The RTO10b grace period for which we will retain tombstoned objects and map entries.
         internal var garbageCollectionGracePeriod: GarbageCollectionOptions.GracePeriod
@@ -677,6 +660,17 @@ internal final class InternalDefaultRealtimeObjects: Sendable, InternalRealtimeO
 
         /// The RTO17 sync state. Also stores the sync sequence data.
         internal var state = State.initialized
+
+        init(
+            objectsPool: ObjectsPool,
+            internalQueue: DispatchQueue,
+            garbageCollectionGracePeriod: GarbageCollectionOptions.GracePeriod,
+        ) {
+            self.objectsPool = objectsPool
+            self.garbageCollectionGracePeriod = garbageCollectionGracePeriod
+            objectsEventSubscriptionStorage = SubscriptionStorage(internalQueue: internalQueue)
+            internalObjectsEventSubscriptionStorage = SubscriptionStorage(internalQueue: internalQueue)
+        }
 
         /// Has the same cases as `ObjectsSyncState` but with associated data to store the sync sequence data and represent the constraint that you only have a sync sequence if you're SYNCING.
         internal enum State {
@@ -726,7 +720,7 @@ internal final class InternalDefaultRealtimeObjects: Sendable, InternalRealtimeO
                 return
             }
             // RTO17b
-            emitObjectsEvent(event, on: userCallbackQueue)
+            nosync_emitObjectsEvent(event, on: userCallbackQueue)
         }
 
         internal mutating func nosync_onChannelAttached(
@@ -1018,23 +1012,14 @@ internal final class InternalDefaultRealtimeObjects: Sendable, InternalRealtimeO
             }
         }
 
-        internal typealias UpdateMutableState = @Sendable (_ action: (inout Self) -> Void) -> Void
-
         @discardableResult
-        internal mutating func on(event: ObjectsEvent, callback: @escaping ObjectsEventCallback, updateSelfLater: @escaping UpdateMutableState) -> any OnObjectsEventResponse {
-            let updateSubscriptionStorage: SubscriptionStorage<ObjectsEvent, Void>.UpdateSubscriptionStorage = { action in
-                updateSelfLater { mutableState in
-                    action(&mutableState.objectsEventSubscriptionStorage)
-                }
-            }
-
-            let subscription = objectsEventSubscriptionStorage.subscribe(
+        internal func nosync_on(event: ObjectsEvent, callback: @escaping ObjectsEventCallback) -> any OnObjectsEventResponse {
+            let subscription = objectsEventSubscriptionStorage.nosync_subscribe(
                 listener: { _, subscriptionInCallback in
                     let response = ObjectsEventResponse(subscription: subscriptionInCallback)
                     callback(response)
                 },
                 eventName: event,
-                updateSelfLater: updateSubscriptionStorage,
             )
 
             return ObjectsEventResponse(subscription: subscription)
@@ -1042,21 +1027,13 @@ internal final class InternalDefaultRealtimeObjects: Sendable, InternalRealtimeO
 
         /// Adds a subscriber to the ``internalObjectsEventSubscriptionStorage`` (i.e. unaffected by `offAll()`).
         @discardableResult
-        internal mutating func onInternal(event: ObjectsEvent, callback: @escaping ObjectsEventCallback, updateSelfLater: @escaping UpdateMutableState) -> any OnObjectsEventResponse {
-            // TODO: Looking at this again later the whole process for adding a subscriber is really verbose and boilerplate-y, and I think the unfortunate result of me trying to be clever at some point; revisit in https://github.com/ably/ably-liveobjects-swift-plugin/issues/102. Also as things stand we end up not being able to use this method because we run into Swift exclusivity violations when we try to unsubscribe from within a listener that's invoked when the mutable state mutex is already held (see https://github.com/ably/ably-liveobjects-swift-plugin/issues/120), so e.g. the RTO20 wait-for-synced can't use this mechanism, which it should be able to.
-            let updateSubscriptionStorage: SubscriptionStorage<ObjectsEvent, Void>.UpdateSubscriptionStorage = { action in
-                updateSelfLater { mutableState in
-                    action(&mutableState.internalObjectsEventSubscriptionStorage)
-                }
-            }
-
-            let subscription = internalObjectsEventSubscriptionStorage.subscribe(
+        internal func nosync_onInternal(event: ObjectsEvent, callback: @escaping ObjectsEventCallback) -> any OnObjectsEventResponse {
+            let subscription = internalObjectsEventSubscriptionStorage.nosync_subscribe(
                 listener: { _, subscriptionInCallback in
                     let response = ObjectsEventResponse(subscription: subscriptionInCallback)
                     callback(response)
                 },
                 eventName: event,
-                updateSelfLater: updateSubscriptionStorage,
             )
 
             return ObjectsEventResponse(subscription: subscription)
@@ -1071,13 +1048,13 @@ internal final class InternalDefaultRealtimeObjects: Sendable, InternalRealtimeO
             }
         }
 
-        internal mutating func offAll() {
-            objectsEventSubscriptionStorage.unsubscribeAll()
+        internal func nosync_offAll() {
+            objectsEventSubscriptionStorage.nosync_unsubscribeAll()
         }
 
-        internal func emitObjectsEvent(_ event: ObjectsEvent, on queue: DispatchQueue) {
-            objectsEventSubscriptionStorage.emit(eventName: event, on: queue)
-            internalObjectsEventSubscriptionStorage.emit(eventName: event, on: queue)
+        internal func nosync_emitObjectsEvent(_ event: ObjectsEvent, on queue: DispatchQueue) {
+            objectsEventSubscriptionStorage.nosync_emit(eventName: event, on: queue)
+            internalObjectsEventSubscriptionStorage.nosync_emit(eventName: event, on: queue)
         }
     }
 }

--- a/Sources/AblyLiveObjects/Internal/InternalEventEmitter.swift
+++ b/Sources/AblyLiveObjects/Internal/InternalEventEmitter.swift
@@ -1,0 +1,8 @@
+// NOTE: This file is adapted from the WIP ably-swift (taken from there at commit 98996f1).
+
+/// An extension of ``EventEmitter`` for use inside the codebase. It represents an `EventEmitter` that can be instructed to emit an event.
+internal protocol InternalEventEmitter<Event, Data>: EventEmitter {
+    func emit(event: Event, data: Data)
+}
+
+// (Note: I wonder whether having a mock InternalEventEmitter might be useful sometimes, when all you care about is whether a given event was emitted without having to go through the palaver of getting this data back out using a callback.)

--- a/Sources/AblyLiveObjects/Internal/InternalEventEmitter.swift
+++ b/Sources/AblyLiveObjects/Internal/InternalEventEmitter.swift
@@ -2,7 +2,8 @@
 
 /// An extension of ``EventEmitter`` for use inside the codebase. It represents an `EventEmitter` that can be instructed to emit an event.
 internal protocol InternalEventEmitter<Event, Data>: EventEmitter {
-    func emit(event: Event, data: Data)
+    /// Emits an event, invoking the registered listeners on the internal queue.
+    func nosync_emit(event: Event, data: Data)
 }
 
 // (Note: I wonder whether having a mock InternalEventEmitter might be useful sometimes, when all you care about is whether a given event was emitted without having to go through the palaver of getting this data back out using a callback.)

--- a/Sources/AblyLiveObjects/Internal/InternalLiveObject.swift
+++ b/Sources/AblyLiveObjects/Internal/InternalLiveObject.swift
@@ -37,7 +37,7 @@ internal extension InternalLiveObject {
         // Emit the deleted lifecycle event
         // Taken from https://github.com/ably/ably-js/blob/e280bff11a4a7627362c5185e764b7ebd0490570/src/plugins/objects/liveobject.ts#L168
         // TODO: Bring in line with spec once it exists (https://github.com/ably/ably-liveobjects-swift-plugin/issues/77)
-        liveObjectMutableState.emitLifecycleEvent(.deleted, on: userCallbackQueue)
+        liveObjectMutableState.nosync_emitLifecycleEvent(.deleted, on: userCallbackQueue)
     }
 
     /// Applies an `OBJECT_DELETE` operation, per RTLO5.

--- a/Sources/AblyLiveObjects/Internal/LiveObjectMutableState.swift
+++ b/Sources/AblyLiveObjects/Internal/LiveObjectMutableState.swift
@@ -25,19 +25,22 @@ internal struct LiveObjectMutableState<Update: Sendable> {
     }
 
     /// Internal subscription storage.
-    private var subscriptionStorage = SubscriptionStorage<EventName, Update>()
+    private let subscriptionStorage: SubscriptionStorage<EventName, Update>
 
     /// Internal lifecycle event subscription storage.
-    private var lifecycleEventSubscriptionStorage = SubscriptionStorage<LiveObjectLifecycleEvent, Void>()
+    private let lifecycleEventSubscriptionStorage: SubscriptionStorage<LiveObjectLifecycleEvent, Void>
 
     internal init(
         objectID: String,
+        internalQueue: DispatchQueue,
         testsOnly_siteTimeserials siteTimeserials: [String: String]? = nil,
         testsOnly_tombstonedAt tombstonedAt: Date? = nil,
     ) {
         self.objectID = objectID
         self.siteTimeserials = siteTimeserials ?? [:]
         self.tombstonedAt = tombstonedAt
+        subscriptionStorage = SubscriptionStorage(internalQueue: internalQueue)
+        lifecycleEventSubscriptionStorage = SubscriptionStorage(internalQueue: internalQueue)
     }
 
     /// Represents parameters of an operation that `canApplyOperation` has decided can be applied to a `LiveObject`.
@@ -79,41 +82,25 @@ internal struct LiveObjectMutableState<Update: Sendable> {
 
     // MARK: - Subscriptions
 
-    internal typealias UpdateLiveObject = @Sendable (_ action: (inout Self) -> Void) -> Void
-
     @discardableResult
-    internal mutating func nosync_subscribe(listener: @escaping LiveObjectUpdateCallback<Update>, coreSDK: CoreSDK, updateSelfLater: @escaping UpdateLiveObject) throws(ARTErrorInfo) -> any AblyLiveObjects.SubscribeResponse {
+    internal func nosync_subscribe(listener: @escaping LiveObjectUpdateCallback<Update>, coreSDK: CoreSDK) throws(ARTErrorInfo) -> any AblyLiveObjects.SubscribeResponse {
         // RTLO4b2
         try coreSDK.nosync_validateChannelState(notIn: [.detached, .failed], operationDescription: "subscribe")
 
-        let updateSubscriptionStorage: SubscriptionStorage<EventName, Update>.UpdateSubscriptionStorage = { action in
-            updateSelfLater { liveObject in
-                action(&liveObject.subscriptionStorage)
-            }
-        }
-
-        return subscriptionStorage.subscribe(
+        return subscriptionStorage.nosync_subscribe(
             listener: listener,
             eventName: .update,
-            updateSelfLater: updateSubscriptionStorage,
         )
     }
 
     @discardableResult
-    internal mutating func on(event: LiveObjectLifecycleEvent, callback: @escaping LiveObjectLifecycleEventCallback, updateSelfLater: @escaping UpdateLiveObject) -> any OnLiveObjectLifecycleEventResponse {
-        let updateSubscriptionStorage: SubscriptionStorage<LiveObjectLifecycleEvent, Void>.UpdateSubscriptionStorage = { action in
-            updateSelfLater { liveObject in
-                action(&liveObject.lifecycleEventSubscriptionStorage)
-            }
-        }
-
-        let subscription = lifecycleEventSubscriptionStorage.subscribe(
+    internal func nosync_on(event: LiveObjectLifecycleEvent, callback: @escaping LiveObjectLifecycleEventCallback) -> any OnLiveObjectLifecycleEventResponse {
+        let subscription = lifecycleEventSubscriptionStorage.nosync_subscribe(
             listener: { _, subscriptionInCallback in
                 let response = LifecycleEventResponse(subscription: subscriptionInCallback)
                 callback(response)
             },
             eventName: event,
-            updateSelfLater: updateSubscriptionStorage,
         )
 
         return LifecycleEventResponse(subscription: subscription)
@@ -127,26 +114,26 @@ internal struct LiveObjectMutableState<Update: Sendable> {
         }
     }
 
-    internal mutating func unsubscribeAll() {
-        subscriptionStorage.unsubscribeAll()
+    internal func nosync_unsubscribeAll() {
+        subscriptionStorage.nosync_unsubscribeAll()
     }
 
-    internal mutating func offAll() {
-        lifecycleEventSubscriptionStorage.unsubscribeAll()
+    internal func nosync_offAll() {
+        lifecycleEventSubscriptionStorage.nosync_unsubscribeAll()
     }
 
-    internal func emit(_ update: LiveObjectUpdate<Update>, on queue: DispatchQueue) {
+    internal func nosync_emit(_ update: LiveObjectUpdate<Update>, on queue: DispatchQueue) {
         switch update {
         case .noop:
             // RTLO4b4c1
             return
         case let .update(update):
             // RTLO4b4c2
-            subscriptionStorage.emit(update, eventName: .update, on: queue)
+            subscriptionStorage.nosync_emit(update, eventName: .update, on: queue)
         }
     }
 
-    internal func emitLifecycleEvent(_ event: LiveObjectLifecycleEvent, on queue: DispatchQueue) {
-        lifecycleEventSubscriptionStorage.emit(eventName: event, on: queue)
+    internal func nosync_emitLifecycleEvent(_ event: LiveObjectLifecycleEvent, on queue: DispatchQueue) {
+        lifecycleEventSubscriptionStorage.nosync_emit(eventName: event, on: queue)
     }
 }

--- a/Sources/AblyLiveObjects/Internal/SubscriptionStorage.swift
+++ b/Sources/AblyLiveObjects/Internal/SubscriptionStorage.swift
@@ -1,81 +1,61 @@
 import Foundation
 
 /// Handles subscription bookkeeping, providing methods for subscribing and emitting events.
-internal struct SubscriptionStorage<EventName: Hashable & Sendable, Update: Sendable> {
-    /// Internal bookkeeping for subscriptions, organized by event name.
-    /// Each event name maps to a dictionary of subscriptions keyed by their ID for O(1) operations.
-    private var subscriptionsByEventName: [EventName: [Subscription.ID: Subscription]] = [:]
+internal final class SubscriptionStorage<EventName: Hashable & Sendable, Update: Sendable>: Sendable {
+    /// The `EventEmitter` that backs this `SubscriptionStorage`.
+    ///
+    /// We wrap the `EventEmitter` implementation ported from ably-swift (in this implementation, listeners are called synchronously on the internal queue and unsubscribing is done via a `SubscriptionController`) to match the current public API of this plugin, in which:
+    ///
+    /// - listeners are dispatched asynchronously to the ably-cocoa callbacks queue
+    /// - unsubscribing is done via the `SubscribeResponse` that is both returned from `subscribe()` and passed as an argument to the listener
+    private let emitter: DefaultInternalEventEmitter<EventName, EmitData>
+    private let internalQueue: DispatchQueue
+
+    /// Bundles the update data together with the queue on which the user's callback should be dispatched.
+    private struct EmitData: Sendable {
+        var update: Update
+        var queue: DispatchQueue
+    }
+
+    internal init(internalQueue: DispatchQueue) {
+        self.internalQueue = internalQueue
+        emitter = DefaultInternalEventEmitter(internalQueue: internalQueue)
+    }
 
     // MARK: - Subscriptions
 
-    private struct Subscription: Identifiable {
-        var id = UUID()
-        var listener: LiveObjectUpdateCallback<Update>
-        var updateSubscriptionStorage: UpdateSubscriptionStorage
-    }
-
-    /// A function that allows a `SubscriptionStorage` to later perform mutations to an externally-held copy of itself. This is used to allow a `SubscribeResponse` to unsubscribe.
-    ///
-    /// Accepts an action, which, if called, should be called with an `inout` reference to the externally-held copy. The function is not required to call this action (for example, if the function holds a weak reference which is now `nil`).
-    ///
-    /// Note that the `SubscriptionStorage` will store a copy of this function and thus this function should be careful not to introduce a strong reference cycle.
-    internal typealias UpdateSubscriptionStorage = @Sendable (_ action: (inout Self) -> Void) -> Void
-
-    private struct SubscribeResponse: AblyLiveObjects.SubscribeResponse {
-        var subscriptionID: Subscription.ID
-        var eventName: EventName
-        var updateSubscriptionStorage: UpdateSubscriptionStorage
-
-        func unsubscribe() {
-            updateSubscriptionStorage { subscriptionStorage in
-                subscriptionStorage.unsubscribe(subscriptionID: subscriptionID, eventName: eventName)
-            }
-        }
-    }
-
     @discardableResult
-    internal mutating func subscribe(
+    internal func nosync_subscribe(
         listener: @escaping LiveObjectUpdateCallback<Update>,
         eventName: EventName,
-        updateSelfLater: @escaping UpdateSubscriptionStorage,
     ) -> any AblyLiveObjects.SubscribeResponse {
-        let subscription = Subscription(listener: listener, updateSubscriptionStorage: updateSelfLater)
+        let controller = SubscriptionController(internalQueue: internalQueue)
+        let subscribeResponse = SubscribeResponse(controller: controller, internalQueue: internalQueue)
 
-        // Initialize the dictionary for this event name if it doesn't exist
-        if subscriptionsByEventName[eventName] == nil {
-            subscriptionsByEventName[eventName] = [:]
+        emitter.nosync_on(eventName, signalledBy: controller.signal) { emitData in
+            emitData.queue.async {
+                listener(emitData.update, subscribeResponse)
+            }
         }
 
-        // Add the subscription to the appropriate event name dictionary
-        subscriptionsByEventName[eventName]?[subscription.id] = subscription
-
-        return SubscribeResponse(subscriptionID: subscription.id, eventName: eventName, updateSubscriptionStorage: updateSelfLater)
+        return subscribeResponse
     }
 
-    internal mutating func unsubscribeAll() {
-        subscriptionsByEventName.removeAll()
+    internal func nosync_unsubscribeAll() {
+        emitter.nosync_off()
     }
 
-    private mutating func unsubscribe(subscriptionID: Subscription.ID, eventName: EventName) {
-        // O(1) removal using dictionary key
-        subscriptionsByEventName[eventName]?.removeValue(forKey: subscriptionID)
-
-        // Clean up empty event name dictionaries
-        if subscriptionsByEventName[eventName]?.isEmpty == true {
-            subscriptionsByEventName.removeValue(forKey: eventName)
-        }
+    internal func nosync_emit(_ update: Update, eventName: EventName, on queue: DispatchQueue) {
+        emitter.nosync_emit(event: eventName, data: EmitData(update: update, queue: queue))
     }
 
-    internal func emit(_ update: Update, eventName: EventName, on queue: DispatchQueue) {
-        // Only emit to subscribers who subscribed to this specific event name
-        guard let subscriptions = subscriptionsByEventName[eventName] else {
-            return
-        }
+    private struct SubscribeResponse: AblyLiveObjects.SubscribeResponse {
+        let controller: SubscriptionController
+        let internalQueue: DispatchQueue
 
-        for subscription in subscriptions.values {
-            queue.async {
-                let response = SubscribeResponse(subscriptionID: subscription.id, eventName: eventName, updateSubscriptionStorage: subscription.updateSubscriptionStorage)
-                subscription.listener(update, response)
+        func unsubscribe() {
+            internalQueue.ably_syncNoDeadlock {
+                controller.nosync_off()
             }
         }
     }
@@ -85,7 +65,7 @@ internal struct SubscriptionStorage<EventName: Hashable & Sendable, Update: Send
 
 internal extension SubscriptionStorage where Update == Void {
     /// Convenience method for emitting events when there's no update data to pass.
-    func emit(eventName: EventName, on queue: DispatchQueue) {
-        emit((), eventName: eventName, on: queue)
+    func nosync_emit(eventName: EventName, on queue: DispatchQueue) {
+        nosync_emit((), eventName: eventName, on: queue)
     }
 }

--- a/Tests/AblyLiveObjectsTests/DefaultInternalEventEmitterTests.swift
+++ b/Tests/AblyLiveObjectsTests/DefaultInternalEventEmitterTests.swift
@@ -1,0 +1,576 @@
+// NOTE: This file is adapted from the WIP ably-swift (taken from there at commit 98996f1).
+
+@testable import AblyLiveObjects
+import Foundation
+import Testing
+
+@MainActor
+struct DefaultInternalEventEmitterTests {
+    // Test event types for testing
+    enum TestEvent: String, Equatable, CaseIterable {
+        case connect
+        case disconnect
+        case message
+    }
+
+    struct TestData: Equatable {
+        let value: String
+    }
+
+    // MARK: - RTE3 Tests (on method)
+
+    @Test
+    func onListenerForAllEvents() async throws {
+        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
+        var receivedEvents: [(TestEvent, TestData)] = []
+
+        // RTE3: Register listener for all events
+        emitter.on { event, data in
+            receivedEvents.append((event, data))
+        }
+
+        let testData = TestData(value: "test")
+        emitter.emit(event: .connect, data: testData)
+        emitter.emit(event: .disconnect, data: testData)
+
+        #expect(receivedEvents.count == 2)
+        #expect(receivedEvents[0].0 == .connect)
+        #expect(receivedEvents[1].0 == .disconnect)
+    }
+
+    @Test
+    func onListenerForSpecificEvent() async throws {
+        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
+        var receivedData: [TestData] = []
+
+        // RTE3: Register listener for specific event
+        emitter.on(.connect) { data in
+            receivedData.append(data)
+        }
+
+        let testData = TestData(value: "test")
+        emitter.emit(event: .connect, data: testData)
+        emitter.emit(event: .disconnect, data: testData) // Should not trigger listener
+
+        #expect(receivedData.count == 1)
+        #expect(receivedData[0].value == "test")
+    }
+
+    @Test
+    func onListenerWithSignal() async throws {
+        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
+        let controller = SubscriptionController()
+        var receivedEvents: [(TestEvent, TestData)] = []
+
+        // RTE3: Register listener with signal
+        emitter.on(signalledBy: controller.signal) { event, data in
+            receivedEvents.append((event, data))
+        }
+
+        let testData = TestData(value: "test")
+        emitter.emit(event: .connect, data: testData)
+
+        // RTE5: Cancel subscription
+        controller.off()
+
+        emitter.emit(event: .disconnect, data: testData) // Should not trigger
+
+        #expect(receivedEvents.count == 1)
+        #expect(receivedEvents[0].0 == .connect)
+    }
+
+    @Test
+    func onListenerMultipleRegistrations() async throws {
+        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
+        var callCount = 0
+
+        let listener: MainActorEventListener<TestEvent, TestData> = { _, _ in
+            callCount += 1
+        }
+
+        // RTE3: If on is called more than once with same listener, it's added multiple times
+        emitter.on(listener)
+        emitter.on(listener)
+
+        let testData = TestData(value: "test")
+        emitter.emit(event: .connect, data: testData)
+
+        #expect(callCount == 2) // Listener should be called twice
+    }
+
+    @Test
+    func onListenerForSpecificEventWithSignal() async throws {
+        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
+        let controller = SubscriptionController()
+        var receivedData: [TestData] = []
+
+        // RTE3: Register listener for specific event with signal
+        emitter.on(.connect, signalledBy: controller.signal) { data in
+            receivedData.append(data)
+        }
+
+        let testData = TestData(value: "test")
+        emitter.emit(event: .connect, data: testData)
+        emitter.emit(event: .disconnect, data: testData) // Should not trigger listener
+
+        #expect(receivedData.count == 1)
+        #expect(receivedData[0].value == "test")
+
+        // RTE5: Cancel subscription
+        controller.off()
+
+        emitter.emit(event: .connect, data: testData) // Should not trigger after off()
+        #expect(receivedData.count == 1) // Should not increment
+    }
+
+    // MARK: - RTE4 Tests (once method)
+
+    @Test
+    func onceListenerForAllEvents() async throws {
+        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
+        var receivedEvents: [(TestEvent, TestData)] = []
+
+        // RTE4: Register one-time listener
+        emitter.once { event, data in
+            receivedEvents.append((event, data))
+        }
+
+        let testData = TestData(value: "test")
+        emitter.emit(event: .connect, data: testData)
+        emitter.emit(event: .disconnect, data: testData) // Should not trigger
+
+        #expect(receivedEvents.count == 1)
+        #expect(receivedEvents[0].0 == .connect)
+    }
+
+    @Test
+    func onceListenerForSpecificEvent() async throws {
+        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
+        var receivedData: [TestData] = []
+
+        // RTE4: Register one-time listener for specific event
+        emitter.once(.connect) { data in
+            receivedData.append(data)
+        }
+
+        let testData = TestData(value: "test")
+        emitter.emit(event: .connect, data: testData)
+        emitter.emit(event: .connect, data: testData) // Should not trigger again
+
+        #expect(receivedData.count == 1)
+        #expect(receivedData[0].value == "test")
+    }
+
+    @Test
+    func onceListenerMultipleRegistrations() async throws {
+        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
+        var callCount = 0
+
+        let listener: MainActorEventListener<TestEvent, TestData> = { _, _ in
+            callCount += 1
+        }
+
+        // RTE4: If once is called multiple times with same listener, each registration is invoked once
+        emitter.once(listener)
+        emitter.once(listener)
+
+        let testData = TestData(value: "test")
+        emitter.emit(event: .connect, data: testData)
+
+        #expect(callCount == 2) // Both registrations should be called once
+
+        emitter.emit(event: .disconnect, data: testData) // Should not trigger any more
+        #expect(callCount == 2) // Count should remain the same
+    }
+
+    @Test
+    func onceListenerWithSignal() async throws {
+        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
+        let controller = SubscriptionController()
+        var receivedEvents: [(TestEvent, TestData)] = []
+
+        // RTE4: Register one-time listener with signal
+        emitter.once(signalledBy: controller.signal) { event, data in
+            receivedEvents.append((event, data))
+        }
+
+        // RTE5: Cancel subscription before it fires
+        controller.off()
+
+        let testData = TestData(value: "test")
+        emitter.emit(event: .connect, data: testData) // Should not trigger due to off()
+
+        #expect(receivedEvents.isEmpty)
+    }
+
+    @Test
+    func onceListenerForSpecificEventWithSignal() async throws {
+        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
+        let controller = SubscriptionController()
+        var receivedData: [TestData] = []
+
+        // RTE4: Register one-time listener for specific event with signal
+        emitter.once(.connect, signalledBy: controller.signal) { data in
+            receivedData.append(data)
+        }
+
+        // RTE5: Cancel subscription before it fires
+        controller.off()
+
+        let testData = TestData(value: "test")
+        emitter.emit(event: .connect, data: testData) // Should not trigger due to off()
+
+        #expect(receivedData.isEmpty)
+    }
+
+    // MARK: - RTE6 Tests (emit method)
+
+    @Test
+    func emitCallsAllRegisteredListeners() async throws {
+        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
+        var allEventCallCount = 0
+        var namedEventCallCount = 0
+
+        emitter.on { _, _ in allEventCallCount += 1 }
+        emitter.on(.connect) { _ in namedEventCallCount += 1 }
+
+        let testData = TestData(value: "test")
+        emitter.emit(event: .connect, data: testData)
+
+        #expect(allEventCallCount == 1)
+        #expect(namedEventCallCount == 1)
+    }
+
+    // MARK: - RTE6a Tests (listener set stability during emit)
+
+    @Test
+    func emitListenerSetStability() async throws {
+        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
+        var callOrder: [String] = []
+
+        emitter.on { _, _ in
+            callOrder.append("first")
+            // Add another listener during emit - should not be called in this emit
+            emitter.on { _, _ in
+                callOrder.append("added-during-emit")
+            }
+        }
+
+        emitter.on { _, _ in
+            callOrder.append("second")
+        }
+
+        let testData = TestData(value: "test")
+        emitter.emit(event: .connect, data: testData)
+
+        // RTE6a: Only original listeners should be called
+        #expect(callOrder == ["first", "second"])
+
+        // Emit again - now the added listener should be called
+        callOrder.removeAll()
+        emitter.emit(event: .disconnect, data: testData)
+        #expect(callOrder == ["first", "second", "added-during-emit"])
+    }
+
+    @Test
+    func emitListenerRemovalDuringEmit() async throws {
+        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
+        let controller = SubscriptionController()
+        var callOrder: [String] = []
+
+        emitter.on { _, _ in
+            callOrder.append("first")
+            // Remove this listener during emit - but it should still complete per RTE6a
+            controller.off()
+        }
+
+        emitter.on(signalledBy: controller.signal) { _, _ in
+            callOrder.append("second")
+        }
+
+        let testData = TestData(value: "test")
+        emitter.emit(event: .connect, data: testData)
+
+        // RTE6a: Both listeners should be called despite removal during emit
+        #expect(callOrder == ["first", "second"])
+
+        // Emit again - now only first listener should be called
+        callOrder.removeAll()
+        emitter.emit(event: .disconnect, data: testData)
+        #expect(callOrder == ["first"])
+    }
+
+    // MARK: - RTE5 Tests (off method)
+
+    @Test
+    func offRemovesAllListeners() async throws {
+        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
+        var allEventCallCount = 0
+        var connectCallCount = 0
+        var disconnectCallCount = 0
+
+        // Register various listeners
+        emitter.on { _, _ in allEventCallCount += 1 }
+        emitter.on(.connect) { _ in connectCallCount += 1 }
+        emitter.on(.disconnect) { _ in disconnectCallCount += 1 }
+
+        let testData = TestData(value: "test")
+
+        // Verify listeners work before off()
+        emitter.emit(event: .connect, data: testData)
+        #expect(allEventCallCount == 1)
+        #expect(connectCallCount == 1)
+        #expect(disconnectCallCount == 0)
+
+        // RTE5: Remove all listeners
+        emitter.off()
+
+        // Reset counters and emit - no listeners should be called
+        allEventCallCount = 0
+        connectCallCount = 0
+        disconnectCallCount = 0
+
+        emitter.emit(event: .connect, data: testData)
+        emitter.emit(event: .disconnect, data: testData)
+
+        #expect(allEventCallCount == 0)
+        #expect(connectCallCount == 0)
+        #expect(disconnectCallCount == 0)
+    }
+
+    @Test
+    func offForSpecificEventRemovesOnlyThatEvent() async throws {
+        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
+        var allEventCallCount = 0
+        var connectCallCount = 0
+        var disconnectCallCount = 0
+
+        // Register various listeners
+        emitter.on { _, _ in allEventCallCount += 1 }
+        emitter.on(.connect) { _ in connectCallCount += 1 }
+        emitter.on(.disconnect) { _ in disconnectCallCount += 1 }
+
+        let testData = TestData(value: "test")
+
+        // Verify listeners work before off()
+        emitter.emit(event: .connect, data: testData)
+        #expect(allEventCallCount == 1)
+        #expect(connectCallCount == 1)
+        #expect(disconnectCallCount == 0)
+
+        // RTE5: Remove only connect listeners
+        emitter.off(.connect)
+
+        // Reset counters and emit - only connect listeners should be removed
+        allEventCallCount = 0
+        connectCallCount = 0
+        disconnectCallCount = 0
+
+        emitter.emit(event: .connect, data: testData)
+        #expect(allEventCallCount == 1) // All-event listener should still work
+        #expect(connectCallCount == 0) // Connect listener should be removed
+        #expect(disconnectCallCount == 0)
+
+        emitter.emit(event: .disconnect, data: testData)
+        #expect(allEventCallCount == 2) // All-event listener should still work
+        #expect(connectCallCount == 0)
+        #expect(disconnectCallCount == 1) // Disconnect listener should still work
+    }
+
+    // MARK: - RTE5 - SubscriptionController Tests
+
+    @Test
+    func subscriptionControllerOff() async throws {
+        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
+        let controller = SubscriptionController()
+        var callCount = 0
+
+        emitter.on(signalledBy: controller.signal) { _, _ in
+            callCount += 1
+        }
+
+        let testData = TestData(value: "test")
+        emitter.emit(event: .connect, data: testData)
+        #expect(callCount == 1)
+
+        controller.off()
+        emitter.emit(event: .disconnect, data: testData)
+        #expect(callCount == 1) // Should not increment
+    }
+
+    @Test
+    func unsubscribeFromWithinListener() async throws {
+        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
+        let controller = SubscriptionController()
+        var callCount = 0
+
+        // Test unsubscribing from within listener callback
+        emitter.on(signalledBy: controller.signal) { _, _ in
+            callCount += 1
+            controller.off() // Unsubscribe from within callback
+        }
+
+        let testData = TestData(value: "test")
+        emitter.emit(event: .connect, data: testData)
+        #expect(callCount == 1)
+
+        // Should not be called again
+        emitter.emit(event: .disconnect, data: testData)
+        #expect(callCount == 1)
+    }
+
+    @Test
+    func subscriptionControllerOffDoesNotAffectFutureSubscriptions() async throws {
+        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
+        let controller = SubscriptionController()
+        var firstCallCount = 0
+        var secondCallCount = 0
+
+        // First subscription
+        emitter.on(signalledBy: controller.signal) { _, _ in
+            firstCallCount += 1
+        }
+
+        let testData = TestData(value: "test")
+        emitter.emit(event: .connect, data: testData)
+        #expect(firstCallCount == 1)
+
+        // Cancel first subscription
+        controller.off()
+
+        // Add another subscription with the same signal - should work
+        emitter.on(signalledBy: controller.signal) { _, _ in
+            secondCallCount += 1
+        }
+
+        emitter.emit(event: .disconnect, data: testData)
+        #expect(firstCallCount == 1) // Should not increment
+        #expect(secondCallCount == 1) // Should work despite previous off() call
+    }
+
+    @Test
+    func subscriptionContinuesAfterControllerDeallocation() async throws {
+        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
+        var callCount = 0
+
+        // Create subscription with controller that will be deallocated
+        weak var weakController: SubscriptionController?
+        do {
+            let controller = SubscriptionController()
+            weakController = controller
+            emitter.on(signalledBy: controller.signal) { _, _ in
+                callCount += 1
+            }
+
+            // Verify subscription works initially
+            let testData = TestData(value: "test")
+            emitter.emit(event: .connect, data: testData)
+            #expect(callCount == 1)
+
+            // Controller will be deallocated when leaving this scope
+        }
+        // Confirm the controller has been deallocated
+        precondition(weakController == nil)
+
+        // Emit another value now that the controller has been deallocated
+        let testData = TestData(value: "test2")
+        emitter.emit(event: .disconnect, data: testData)
+
+        // The subscription should still work because listener registration is independent
+        // of controller lifetime - only calling off() should remove it
+        #expect(callCount == 2)
+    }
+
+    // MARK: - Mixed Scenarios Tests
+
+    @Test
+    func mixedOnAndOnceListeners() async throws {
+        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
+        var onCallCount = 0
+        var onceCallCount = 0
+
+        emitter.on { _, _ in onCallCount += 1 }
+        emitter.once { _, _ in onceCallCount += 1 }
+
+        let testData = TestData(value: "test")
+        emitter.emit(event: .connect, data: testData)
+        #expect(onCallCount == 1)
+        #expect(onceCallCount == 1)
+
+        emitter.emit(event: .disconnect, data: testData)
+        #expect(onCallCount == 2) // Should increment
+        #expect(onceCallCount == 1) // Should not increment
+    }
+
+    @Test
+    func mixedAllEventAndNamedEventListeners() async throws {
+        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
+        var allEventCallCount = 0
+        var connectCallCount = 0
+        var disconnectCallCount = 0
+
+        emitter.on { _, _ in allEventCallCount += 1 }
+        emitter.on(.connect) { _ in connectCallCount += 1 }
+        emitter.on(.disconnect) { _ in disconnectCallCount += 1 }
+
+        let testData = TestData(value: "test")
+
+        emitter.emit(event: .connect, data: testData)
+        #expect(allEventCallCount == 1)
+        #expect(connectCallCount == 1)
+        #expect(disconnectCallCount == 0)
+
+        emitter.emit(event: .disconnect, data: testData)
+        #expect(allEventCallCount == 2)
+        #expect(connectCallCount == 1)
+        #expect(disconnectCallCount == 1)
+
+        emitter.emit(event: .message, data: testData)
+        #expect(allEventCallCount == 3)
+        #expect(connectCallCount == 1)
+        #expect(disconnectCallCount == 1)
+    }
+
+    @Test
+    func complexScenario() async throws {
+        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
+        let controller1 = SubscriptionController()
+        let controller2 = SubscriptionController()
+        var results: [String] = []
+
+        // Mix of on/once, all-event/named-event, with/without signals
+        emitter.on { event, _ in results.append("all-on-\(event)") }
+        emitter.once { event, _ in results.append("all-once-\(event)") }
+        emitter.on(.connect) { _ in results.append("connect-on") }
+        emitter.once(.connect) { _ in results.append("connect-once") }
+        emitter.on(signalledBy: controller1.signal) { event, _ in results.append("signal1-\(event)") }
+        emitter.on(.connect, signalledBy: controller2.signal) { _ in results.append("connect-signal2") }
+
+        let testData = TestData(value: "test")
+
+        // First emit
+        emitter.emit(event: .connect, data: testData)
+        #expect(results.count == 6)
+        #expect(results.contains("all-on-connect"))
+        #expect(results.contains("all-once-connect"))
+        #expect(results.contains("connect-on"))
+        #expect(results.contains("connect-once"))
+        #expect(results.contains("signal1-connect"))
+        #expect(results.contains("connect-signal2"))
+
+        results.removeAll()
+
+        // Cancel one signal
+        controller1.off()
+
+        // Second emit
+        emitter.emit(event: .connect, data: testData)
+        #expect(results.count == 3) // once listeners should not fire again, signal1 should not fire
+        #expect(results.contains("all-on-connect"))
+        #expect(results.contains("connect-on"))
+        #expect(results.contains("connect-signal2"))
+        #expect(!results.contains("all-once-connect"))
+        #expect(!results.contains("connect-once"))
+        #expect(!results.contains("signal1-connect"))
+    }
+}

--- a/Tests/AblyLiveObjectsTests/DefaultInternalEventEmitterTests.swift
+++ b/Tests/AblyLiveObjectsTests/DefaultInternalEventEmitterTests.swift
@@ -4,468 +4,550 @@
 import Foundation
 import Testing
 
-@MainActor
 struct DefaultInternalEventEmitterTests {
     // Test event types for testing
-    enum TestEvent: String, Equatable, CaseIterable {
+    enum TestEvent: String, Equatable, CaseIterable, Sendable {
         case connect
         case disconnect
         case message
     }
 
-    struct TestData: Equatable {
+    struct TestData: Equatable, Sendable {
         let value: String
     }
 
     // MARK: - RTE3 Tests (on method)
 
     @Test
-    func onListenerForAllEvents() async throws {
-        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
-        var receivedEvents: [(TestEvent, TestData)] = []
+    func onListenerForAllEvents() {
+        let internalQueue = TestFactories.createInternalQueue()
 
-        // RTE3: Register listener for all events
-        emitter.on { event, data in
-            receivedEvents.append((event, data))
+        internalQueue.ably_syncNoDeadlock {
+            let emitter = DefaultInternalEventEmitter<TestEvent, TestData>(internalQueue: internalQueue)
+            let receivedEvents = DispatchQueueMutex<[(TestEvent, TestData)]>(dispatchQueue: internalQueue, initialValue: [])
+
+            // RTE3: Register listener for all events
+            emitter.nosync_on { event, data in
+                receivedEvents.withoutSync { $0.append((event, data)) }
+            }
+
+            let testData = TestData(value: "test")
+            emitter.nosync_emit(event: .connect, data: testData)
+            emitter.nosync_emit(event: .disconnect, data: testData)
+
+            let received = receivedEvents.withoutSync { $0 }
+            #expect(received.count == 2)
+            #expect(received[0].0 == .connect)
+            #expect(received[1].0 == .disconnect)
         }
-
-        let testData = TestData(value: "test")
-        emitter.emit(event: .connect, data: testData)
-        emitter.emit(event: .disconnect, data: testData)
-
-        #expect(receivedEvents.count == 2)
-        #expect(receivedEvents[0].0 == .connect)
-        #expect(receivedEvents[1].0 == .disconnect)
     }
 
     @Test
-    func onListenerForSpecificEvent() async throws {
-        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
-        var receivedData: [TestData] = []
+    func onListenerForSpecificEvent() {
+        let internalQueue = TestFactories.createInternalQueue()
 
-        // RTE3: Register listener for specific event
-        emitter.on(.connect) { data in
-            receivedData.append(data)
+        internalQueue.ably_syncNoDeadlock {
+            let emitter = DefaultInternalEventEmitter<TestEvent, TestData>(internalQueue: internalQueue)
+            let receivedData = DispatchQueueMutex<[TestData]>(dispatchQueue: internalQueue, initialValue: [])
+
+            // RTE3: Register listener for specific event
+            emitter.nosync_on(.connect) { data in
+                receivedData.withoutSync { $0.append(data) }
+            }
+
+            let testData = TestData(value: "test")
+            emitter.nosync_emit(event: .connect, data: testData)
+            emitter.nosync_emit(event: .disconnect, data: testData) // Should not trigger listener
+
+            let received = receivedData.withoutSync { $0 }
+            #expect(received.count == 1)
+            #expect(received[0].value == "test")
         }
-
-        let testData = TestData(value: "test")
-        emitter.emit(event: .connect, data: testData)
-        emitter.emit(event: .disconnect, data: testData) // Should not trigger listener
-
-        #expect(receivedData.count == 1)
-        #expect(receivedData[0].value == "test")
     }
 
     @Test
-    func onListenerWithSignal() async throws {
-        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
-        let controller = SubscriptionController()
-        var receivedEvents: [(TestEvent, TestData)] = []
+    func onListenerWithSignal() {
+        let internalQueue = TestFactories.createInternalQueue()
 
-        // RTE3: Register listener with signal
-        emitter.on(signalledBy: controller.signal) { event, data in
-            receivedEvents.append((event, data))
+        internalQueue.ably_syncNoDeadlock {
+            let emitter = DefaultInternalEventEmitter<TestEvent, TestData>(internalQueue: internalQueue)
+            let controller = SubscriptionController(internalQueue: internalQueue)
+            let receivedEvents = DispatchQueueMutex<[(TestEvent, TestData)]>(dispatchQueue: internalQueue, initialValue: [])
+
+            // RTE3: Register listener with signal
+            emitter.nosync_on(signalledBy: controller.signal) { event, data in
+                receivedEvents.withoutSync { $0.append((event, data)) }
+            }
+
+            let testData = TestData(value: "test")
+            emitter.nosync_emit(event: .connect, data: testData)
+
+            // RTE5: Cancel subscription
+            controller.nosync_off()
+
+            emitter.nosync_emit(event: .disconnect, data: testData) // Should not trigger
+
+            let received = receivedEvents.withoutSync { $0 }
+            #expect(received.count == 1)
+            #expect(received[0].0 == .connect)
         }
-
-        let testData = TestData(value: "test")
-        emitter.emit(event: .connect, data: testData)
-
-        // RTE5: Cancel subscription
-        controller.off()
-
-        emitter.emit(event: .disconnect, data: testData) // Should not trigger
-
-        #expect(receivedEvents.count == 1)
-        #expect(receivedEvents[0].0 == .connect)
     }
 
     @Test
-    func onListenerMultipleRegistrations() async throws {
-        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
-        var callCount = 0
+    func onListenerMultipleRegistrations() {
+        let internalQueue = TestFactories.createInternalQueue()
 
-        let listener: MainActorEventListener<TestEvent, TestData> = { _, _ in
-            callCount += 1
+        internalQueue.ably_syncNoDeadlock {
+            let emitter = DefaultInternalEventEmitter<TestEvent, TestData>(internalQueue: internalQueue)
+            let callCount = DispatchQueueMutex(dispatchQueue: internalQueue, initialValue: 0)
+
+            let listener: EventListener<TestEvent, TestData> = { _, _ in
+                callCount.withoutSync { $0 += 1 }
+            }
+
+            // RTE3: If on is called more than once with same listener, it's added multiple times
+            emitter.nosync_on(listener)
+            emitter.nosync_on(listener)
+
+            let testData = TestData(value: "test")
+            emitter.nosync_emit(event: .connect, data: testData)
+
+            #expect(callCount.withoutSync { $0 } == 2) // Listener should be called twice
         }
-
-        // RTE3: If on is called more than once with same listener, it's added multiple times
-        emitter.on(listener)
-        emitter.on(listener)
-
-        let testData = TestData(value: "test")
-        emitter.emit(event: .connect, data: testData)
-
-        #expect(callCount == 2) // Listener should be called twice
     }
 
     @Test
-    func onListenerForSpecificEventWithSignal() async throws {
-        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
-        let controller = SubscriptionController()
-        var receivedData: [TestData] = []
+    func onListenerForSpecificEventWithSignal() {
+        let internalQueue = TestFactories.createInternalQueue()
 
-        // RTE3: Register listener for specific event with signal
-        emitter.on(.connect, signalledBy: controller.signal) { data in
-            receivedData.append(data)
+        internalQueue.ably_syncNoDeadlock {
+            let emitter = DefaultInternalEventEmitter<TestEvent, TestData>(internalQueue: internalQueue)
+            let controller = SubscriptionController(internalQueue: internalQueue)
+            let receivedData = DispatchQueueMutex<[TestData]>(dispatchQueue: internalQueue, initialValue: [])
+
+            // RTE3: Register listener for specific event with signal
+            emitter.nosync_on(.connect, signalledBy: controller.signal) { data in
+                receivedData.withoutSync { $0.append(data) }
+            }
+
+            let testData = TestData(value: "test")
+            emitter.nosync_emit(event: .connect, data: testData)
+            emitter.nosync_emit(event: .disconnect, data: testData) // Should not trigger listener
+
+            let received = receivedData.withoutSync { $0 }
+            #expect(received.count == 1)
+            #expect(received[0].value == "test")
+
+            // RTE5: Cancel subscription
+            controller.nosync_off()
+
+            emitter.nosync_emit(event: .connect, data: testData) // Should not trigger after nosync_off()
+            #expect(receivedData.withoutSync { $0.count } == 1) // Should not increment
         }
-
-        let testData = TestData(value: "test")
-        emitter.emit(event: .connect, data: testData)
-        emitter.emit(event: .disconnect, data: testData) // Should not trigger listener
-
-        #expect(receivedData.count == 1)
-        #expect(receivedData[0].value == "test")
-
-        // RTE5: Cancel subscription
-        controller.off()
-
-        emitter.emit(event: .connect, data: testData) // Should not trigger after off()
-        #expect(receivedData.count == 1) // Should not increment
     }
 
     // MARK: - RTE4 Tests (once method)
 
     @Test
-    func onceListenerForAllEvents() async throws {
-        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
-        var receivedEvents: [(TestEvent, TestData)] = []
+    func onceListenerForAllEvents() {
+        let internalQueue = TestFactories.createInternalQueue()
 
-        // RTE4: Register one-time listener
-        emitter.once { event, data in
-            receivedEvents.append((event, data))
+        internalQueue.ably_syncNoDeadlock {
+            let emitter = DefaultInternalEventEmitter<TestEvent, TestData>(internalQueue: internalQueue)
+            let receivedEvents = DispatchQueueMutex<[(TestEvent, TestData)]>(dispatchQueue: internalQueue, initialValue: [])
+
+            // RTE4: Register one-time listener
+            emitter.nosync_once { event, data in
+                receivedEvents.withoutSync { $0.append((event, data)) }
+            }
+
+            let testData = TestData(value: "test")
+            emitter.nosync_emit(event: .connect, data: testData)
+            emitter.nosync_emit(event: .disconnect, data: testData) // Should not trigger
+
+            let received = receivedEvents.withoutSync { $0 }
+            #expect(received.count == 1)
+            #expect(received[0].0 == .connect)
         }
-
-        let testData = TestData(value: "test")
-        emitter.emit(event: .connect, data: testData)
-        emitter.emit(event: .disconnect, data: testData) // Should not trigger
-
-        #expect(receivedEvents.count == 1)
-        #expect(receivedEvents[0].0 == .connect)
     }
 
     @Test
-    func onceListenerForSpecificEvent() async throws {
-        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
-        var receivedData: [TestData] = []
+    func onceListenerForSpecificEvent() {
+        let internalQueue = TestFactories.createInternalQueue()
 
-        // RTE4: Register one-time listener for specific event
-        emitter.once(.connect) { data in
-            receivedData.append(data)
+        internalQueue.ably_syncNoDeadlock {
+            let emitter = DefaultInternalEventEmitter<TestEvent, TestData>(internalQueue: internalQueue)
+            let receivedData = DispatchQueueMutex<[TestData]>(dispatchQueue: internalQueue, initialValue: [])
+
+            // RTE4: Register one-time listener for specific event
+            emitter.nosync_once(.connect) { data in
+                receivedData.withoutSync { $0.append(data) }
+            }
+
+            let testData = TestData(value: "test")
+            emitter.nosync_emit(event: .connect, data: testData)
+            emitter.nosync_emit(event: .connect, data: testData) // Should not trigger again
+
+            let received = receivedData.withoutSync { $0 }
+            #expect(received.count == 1)
+            #expect(received[0].value == "test")
         }
-
-        let testData = TestData(value: "test")
-        emitter.emit(event: .connect, data: testData)
-        emitter.emit(event: .connect, data: testData) // Should not trigger again
-
-        #expect(receivedData.count == 1)
-        #expect(receivedData[0].value == "test")
     }
 
     @Test
-    func onceListenerMultipleRegistrations() async throws {
-        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
-        var callCount = 0
+    func onceListenerMultipleRegistrations() {
+        let internalQueue = TestFactories.createInternalQueue()
 
-        let listener: MainActorEventListener<TestEvent, TestData> = { _, _ in
-            callCount += 1
+        internalQueue.ably_syncNoDeadlock {
+            let emitter = DefaultInternalEventEmitter<TestEvent, TestData>(internalQueue: internalQueue)
+            let callCount = DispatchQueueMutex(dispatchQueue: internalQueue, initialValue: 0)
+
+            let listener: EventListener<TestEvent, TestData> = { _, _ in
+                callCount.withoutSync { $0 += 1 }
+            }
+
+            // RTE4: If once is called multiple times with same listener, each registration is invoked once
+            emitter.nosync_once(listener)
+            emitter.nosync_once(listener)
+
+            let testData = TestData(value: "test")
+            emitter.nosync_emit(event: .connect, data: testData)
+
+            #expect(callCount.withoutSync { $0 } == 2) // Both registrations should be called once
+
+            emitter.nosync_emit(event: .disconnect, data: testData) // Should not trigger any more
+            #expect(callCount.withoutSync { $0 } == 2) // Count should remain the same
         }
-
-        // RTE4: If once is called multiple times with same listener, each registration is invoked once
-        emitter.once(listener)
-        emitter.once(listener)
-
-        let testData = TestData(value: "test")
-        emitter.emit(event: .connect, data: testData)
-
-        #expect(callCount == 2) // Both registrations should be called once
-
-        emitter.emit(event: .disconnect, data: testData) // Should not trigger any more
-        #expect(callCount == 2) // Count should remain the same
     }
 
     @Test
-    func onceListenerWithSignal() async throws {
-        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
-        let controller = SubscriptionController()
-        var receivedEvents: [(TestEvent, TestData)] = []
+    func onceListenerWithSignal() {
+        let internalQueue = TestFactories.createInternalQueue()
 
-        // RTE4: Register one-time listener with signal
-        emitter.once(signalledBy: controller.signal) { event, data in
-            receivedEvents.append((event, data))
+        internalQueue.ably_syncNoDeadlock {
+            let emitter = DefaultInternalEventEmitter<TestEvent, TestData>(internalQueue: internalQueue)
+            let controller = SubscriptionController(internalQueue: internalQueue)
+            let receivedEvents = DispatchQueueMutex<[(TestEvent, TestData)]>(dispatchQueue: internalQueue, initialValue: [])
+
+            // RTE4: Register one-time listener with signal
+            emitter.nosync_once(signalledBy: controller.signal) { event, data in
+                receivedEvents.withoutSync { $0.append((event, data)) }
+            }
+
+            // RTE5: Cancel subscription before it fires
+            controller.nosync_off()
+
+            let testData = TestData(value: "test")
+            emitter.nosync_emit(event: .connect, data: testData) // Should not trigger due to nosync_off()
+
+            #expect(receivedEvents.withoutSync { $0 }.isEmpty)
         }
-
-        // RTE5: Cancel subscription before it fires
-        controller.off()
-
-        let testData = TestData(value: "test")
-        emitter.emit(event: .connect, data: testData) // Should not trigger due to off()
-
-        #expect(receivedEvents.isEmpty)
     }
 
     @Test
-    func onceListenerForSpecificEventWithSignal() async throws {
-        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
-        let controller = SubscriptionController()
-        var receivedData: [TestData] = []
+    func onceListenerForSpecificEventWithSignal() {
+        let internalQueue = TestFactories.createInternalQueue()
 
-        // RTE4: Register one-time listener for specific event with signal
-        emitter.once(.connect, signalledBy: controller.signal) { data in
-            receivedData.append(data)
+        internalQueue.ably_syncNoDeadlock {
+            let emitter = DefaultInternalEventEmitter<TestEvent, TestData>(internalQueue: internalQueue)
+            let controller = SubscriptionController(internalQueue: internalQueue)
+            let receivedData = DispatchQueueMutex<[TestData]>(dispatchQueue: internalQueue, initialValue: [])
+
+            // RTE4: Register one-time listener for specific event with signal
+            emitter.nosync_once(.connect, signalledBy: controller.signal) { data in
+                receivedData.withoutSync { $0.append(data) }
+            }
+
+            // RTE5: Cancel subscription before it fires
+            controller.nosync_off()
+
+            let testData = TestData(value: "test")
+            emitter.nosync_emit(event: .connect, data: testData) // Should not trigger due to nosync_off()
+
+            #expect(receivedData.withoutSync { $0 }.isEmpty)
         }
-
-        // RTE5: Cancel subscription before it fires
-        controller.off()
-
-        let testData = TestData(value: "test")
-        emitter.emit(event: .connect, data: testData) // Should not trigger due to off()
-
-        #expect(receivedData.isEmpty)
     }
 
     // MARK: - RTE6 Tests (emit method)
 
     @Test
-    func emitCallsAllRegisteredListeners() async throws {
-        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
-        var allEventCallCount = 0
-        var namedEventCallCount = 0
+    func emitCallsAllRegisteredListeners() {
+        let internalQueue = TestFactories.createInternalQueue()
 
-        emitter.on { _, _ in allEventCallCount += 1 }
-        emitter.on(.connect) { _ in namedEventCallCount += 1 }
+        internalQueue.ably_syncNoDeadlock {
+            let emitter = DefaultInternalEventEmitter<TestEvent, TestData>(internalQueue: internalQueue)
+            let allEventCallCount = DispatchQueueMutex(dispatchQueue: internalQueue, initialValue: 0)
+            let namedEventCallCount = DispatchQueueMutex(dispatchQueue: internalQueue, initialValue: 0)
 
-        let testData = TestData(value: "test")
-        emitter.emit(event: .connect, data: testData)
+            emitter.nosync_on { _, _ in allEventCallCount.withoutSync { $0 += 1 } }
+            emitter.nosync_on(.connect) { _ in namedEventCallCount.withoutSync { $0 += 1 } }
 
-        #expect(allEventCallCount == 1)
-        #expect(namedEventCallCount == 1)
+            let testData = TestData(value: "test")
+            emitter.nosync_emit(event: .connect, data: testData)
+
+            #expect(allEventCallCount.withoutSync { $0 } == 1)
+            #expect(namedEventCallCount.withoutSync { $0 } == 1)
+        }
     }
 
     // MARK: - RTE6a Tests (listener set stability during emit)
 
     @Test
-    func emitListenerSetStability() async throws {
-        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
-        var callOrder: [String] = []
+    func emitListenerSetStability() {
+        let internalQueue = TestFactories.createInternalQueue()
 
-        emitter.on { _, _ in
-            callOrder.append("first")
-            // Add another listener during emit - should not be called in this emit
-            emitter.on { _, _ in
-                callOrder.append("added-during-emit")
+        internalQueue.ably_syncNoDeadlock {
+            let emitter = DefaultInternalEventEmitter<TestEvent, TestData>(internalQueue: internalQueue)
+            let callOrder = DispatchQueueMutex<[String]>(dispatchQueue: internalQueue, initialValue: [])
+
+            emitter.nosync_on { _, _ in
+                callOrder.withoutSync { $0.append("first") }
+                // Add another listener during emit - should not be called in this emit
+                emitter.nosync_on { _, _ in
+                    callOrder.withoutSync { $0.append("added-during-emit") }
+                }
             }
+
+            emitter.nosync_on { _, _ in
+                callOrder.withoutSync { $0.append("second") }
+            }
+
+            let testData = TestData(value: "test")
+            emitter.nosync_emit(event: .connect, data: testData)
+
+            // RTE6a: Only original listeners should be called
+            #expect(callOrder.withoutSync { $0 } == ["first", "second"])
+
+            // Emit again - now the added listener should be called
+            callOrder.withoutSync { $0.removeAll() }
+            emitter.nosync_emit(event: .disconnect, data: testData)
+
+            #expect(callOrder.withoutSync { $0 } == ["first", "second", "added-during-emit"])
         }
-
-        emitter.on { _, _ in
-            callOrder.append("second")
-        }
-
-        let testData = TestData(value: "test")
-        emitter.emit(event: .connect, data: testData)
-
-        // RTE6a: Only original listeners should be called
-        #expect(callOrder == ["first", "second"])
-
-        // Emit again - now the added listener should be called
-        callOrder.removeAll()
-        emitter.emit(event: .disconnect, data: testData)
-        #expect(callOrder == ["first", "second", "added-during-emit"])
     }
 
     @Test
-    func emitListenerRemovalDuringEmit() async throws {
-        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
-        let controller = SubscriptionController()
-        var callOrder: [String] = []
+    func emitListenerRemovalDuringEmit() {
+        let internalQueue = TestFactories.createInternalQueue()
 
-        emitter.on { _, _ in
-            callOrder.append("first")
-            // Remove this listener during emit - but it should still complete per RTE6a
-            controller.off()
+        internalQueue.ably_syncNoDeadlock {
+            let emitter = DefaultInternalEventEmitter<TestEvent, TestData>(internalQueue: internalQueue)
+            let controller = SubscriptionController(internalQueue: internalQueue)
+            let callOrder = DispatchQueueMutex<[String]>(dispatchQueue: internalQueue, initialValue: [])
+
+            emitter.nosync_on { _, _ in
+                callOrder.withoutSync { $0.append("first") }
+                // Remove this listener during emit - but it should still complete per RTE6a
+                controller.nosync_off()
+            }
+
+            emitter.nosync_on(signalledBy: controller.signal) { _, _ in
+                callOrder.withoutSync { $0.append("second") }
+            }
+
+            let testData = TestData(value: "test")
+            emitter.nosync_emit(event: .connect, data: testData)
+
+            // RTE6a: Both listeners should be called despite removal during emit
+            #expect(callOrder.withoutSync { $0 } == ["first", "second"])
+
+            // Emit again - now only first listener should be called
+            callOrder.withoutSync { $0.removeAll() }
+            emitter.nosync_emit(event: .disconnect, data: testData)
+
+            #expect(callOrder.withoutSync { $0 } == ["first"])
         }
-
-        emitter.on(signalledBy: controller.signal) { _, _ in
-            callOrder.append("second")
-        }
-
-        let testData = TestData(value: "test")
-        emitter.emit(event: .connect, data: testData)
-
-        // RTE6a: Both listeners should be called despite removal during emit
-        #expect(callOrder == ["first", "second"])
-
-        // Emit again - now only first listener should be called
-        callOrder.removeAll()
-        emitter.emit(event: .disconnect, data: testData)
-        #expect(callOrder == ["first"])
     }
 
     // MARK: - RTE5 Tests (off method)
 
     @Test
-    func offRemovesAllListeners() async throws {
-        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
-        var allEventCallCount = 0
-        var connectCallCount = 0
-        var disconnectCallCount = 0
+    func offRemovesAllListeners() {
+        let internalQueue = TestFactories.createInternalQueue()
 
-        // Register various listeners
-        emitter.on { _, _ in allEventCallCount += 1 }
-        emitter.on(.connect) { _ in connectCallCount += 1 }
-        emitter.on(.disconnect) { _ in disconnectCallCount += 1 }
+        internalQueue.ably_syncNoDeadlock {
+            let emitter = DefaultInternalEventEmitter<TestEvent, TestData>(internalQueue: internalQueue)
+            let allEventCallCount = DispatchQueueMutex(dispatchQueue: internalQueue, initialValue: 0)
+            let connectCallCount = DispatchQueueMutex(dispatchQueue: internalQueue, initialValue: 0)
+            let disconnectCallCount = DispatchQueueMutex(dispatchQueue: internalQueue, initialValue: 0)
 
-        let testData = TestData(value: "test")
+            // Register various listeners
+            emitter.nosync_on { _, _ in allEventCallCount.withoutSync { $0 += 1 } }
+            emitter.nosync_on(.connect) { _ in connectCallCount.withoutSync { $0 += 1 } }
+            emitter.nosync_on(.disconnect) { _ in disconnectCallCount.withoutSync { $0 += 1 } }
 
-        // Verify listeners work before off()
-        emitter.emit(event: .connect, data: testData)
-        #expect(allEventCallCount == 1)
-        #expect(connectCallCount == 1)
-        #expect(disconnectCallCount == 0)
+            let testData = TestData(value: "test")
 
-        // RTE5: Remove all listeners
-        emitter.off()
+            // Verify listeners work before nosync_off()
+            emitter.nosync_emit(event: .connect, data: testData)
+            #expect(allEventCallCount.withoutSync { $0 } == 1)
+            #expect(connectCallCount.withoutSync { $0 } == 1)
+            #expect(disconnectCallCount.withoutSync { $0 } == 0)
 
-        // Reset counters and emit - no listeners should be called
-        allEventCallCount = 0
-        connectCallCount = 0
-        disconnectCallCount = 0
+            // RTE5: Remove all listeners
+            emitter.nosync_off()
 
-        emitter.emit(event: .connect, data: testData)
-        emitter.emit(event: .disconnect, data: testData)
+            // Emit again - no listeners should be called
+            allEventCallCount.withoutSync { $0 = 0 }
+            connectCallCount.withoutSync { $0 = 0 }
+            disconnectCallCount.withoutSync { $0 = 0 }
 
-        #expect(allEventCallCount == 0)
-        #expect(connectCallCount == 0)
-        #expect(disconnectCallCount == 0)
+            emitter.nosync_emit(event: .connect, data: testData)
+            emitter.nosync_emit(event: .disconnect, data: testData)
+
+            #expect(allEventCallCount.withoutSync { $0 } == 0)
+            #expect(connectCallCount.withoutSync { $0 } == 0)
+            #expect(disconnectCallCount.withoutSync { $0 } == 0)
+        }
     }
 
     @Test
-    func offForSpecificEventRemovesOnlyThatEvent() async throws {
-        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
-        var allEventCallCount = 0
-        var connectCallCount = 0
-        var disconnectCallCount = 0
+    func offForSpecificEventRemovesOnlyThatEvent() {
+        let internalQueue = TestFactories.createInternalQueue()
 
-        // Register various listeners
-        emitter.on { _, _ in allEventCallCount += 1 }
-        emitter.on(.connect) { _ in connectCallCount += 1 }
-        emitter.on(.disconnect) { _ in disconnectCallCount += 1 }
+        internalQueue.ably_syncNoDeadlock {
+            let emitter = DefaultInternalEventEmitter<TestEvent, TestData>(internalQueue: internalQueue)
+            let allEventCallCount = DispatchQueueMutex(dispatchQueue: internalQueue, initialValue: 0)
+            let connectCallCount = DispatchQueueMutex(dispatchQueue: internalQueue, initialValue: 0)
+            let disconnectCallCount = DispatchQueueMutex(dispatchQueue: internalQueue, initialValue: 0)
 
-        let testData = TestData(value: "test")
+            // Register various listeners
+            emitter.nosync_on { _, _ in allEventCallCount.withoutSync { $0 += 1 } }
+            emitter.nosync_on(.connect) { _ in connectCallCount.withoutSync { $0 += 1 } }
+            emitter.nosync_on(.disconnect) { _ in disconnectCallCount.withoutSync { $0 += 1 } }
 
-        // Verify listeners work before off()
-        emitter.emit(event: .connect, data: testData)
-        #expect(allEventCallCount == 1)
-        #expect(connectCallCount == 1)
-        #expect(disconnectCallCount == 0)
+            let testData = TestData(value: "test")
 
-        // RTE5: Remove only connect listeners
-        emitter.off(.connect)
+            // Verify listeners work before nosync_off()
+            emitter.nosync_emit(event: .connect, data: testData)
+            #expect(allEventCallCount.withoutSync { $0 } == 1)
+            #expect(connectCallCount.withoutSync { $0 } == 1)
+            #expect(disconnectCallCount.withoutSync { $0 } == 0)
 
-        // Reset counters and emit - only connect listeners should be removed
-        allEventCallCount = 0
-        connectCallCount = 0
-        disconnectCallCount = 0
+            // RTE5: Remove only connect listeners
+            emitter.nosync_off(.connect)
 
-        emitter.emit(event: .connect, data: testData)
-        #expect(allEventCallCount == 1) // All-event listener should still work
-        #expect(connectCallCount == 0) // Connect listener should be removed
-        #expect(disconnectCallCount == 0)
+            // Reset counters and emit - only connect listeners should be removed
+            allEventCallCount.withoutSync { $0 = 0 }
+            connectCallCount.withoutSync { $0 = 0 }
+            disconnectCallCount.withoutSync { $0 = 0 }
 
-        emitter.emit(event: .disconnect, data: testData)
-        #expect(allEventCallCount == 2) // All-event listener should still work
-        #expect(connectCallCount == 0)
-        #expect(disconnectCallCount == 1) // Disconnect listener should still work
+            emitter.nosync_emit(event: .connect, data: testData)
+            #expect(allEventCallCount.withoutSync { $0 } == 1) // All-event listener should still work
+            #expect(connectCallCount.withoutSync { $0 } == 0) // Connect listener should be removed
+            #expect(disconnectCallCount.withoutSync { $0 } == 0)
+
+            emitter.nosync_emit(event: .disconnect, data: testData)
+            #expect(allEventCallCount.withoutSync { $0 } == 2) // All-event listener should still work
+            #expect(connectCallCount.withoutSync { $0 } == 0)
+            #expect(disconnectCallCount.withoutSync { $0 } == 1) // Disconnect listener should still work
+        }
     }
 
     // MARK: - RTE5 - SubscriptionController Tests
 
     @Test
-    func subscriptionControllerOff() async throws {
-        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
-        let controller = SubscriptionController()
-        var callCount = 0
+    func subscriptionControllerOff() {
+        let internalQueue = TestFactories.createInternalQueue()
 
-        emitter.on(signalledBy: controller.signal) { _, _ in
-            callCount += 1
+        internalQueue.ably_syncNoDeadlock {
+            let emitter = DefaultInternalEventEmitter<TestEvent, TestData>(internalQueue: internalQueue)
+            let controller = SubscriptionController(internalQueue: internalQueue)
+            let callCount = DispatchQueueMutex(dispatchQueue: internalQueue, initialValue: 0)
+
+            emitter.nosync_on(signalledBy: controller.signal) { _, _ in
+                callCount.withoutSync { $0 += 1 }
+            }
+
+            let testData = TestData(value: "test")
+            emitter.nosync_emit(event: .connect, data: testData)
+            #expect(callCount.withoutSync { $0 } == 1)
+
+            controller.nosync_off()
+            emitter.nosync_emit(event: .disconnect, data: testData)
+            #expect(callCount.withoutSync { $0 } == 1) // Should not increment
         }
-
-        let testData = TestData(value: "test")
-        emitter.emit(event: .connect, data: testData)
-        #expect(callCount == 1)
-
-        controller.off()
-        emitter.emit(event: .disconnect, data: testData)
-        #expect(callCount == 1) // Should not increment
     }
 
     @Test
-    func unsubscribeFromWithinListener() async throws {
-        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
-        let controller = SubscriptionController()
-        var callCount = 0
+    func unsubscribeFromWithinListener() {
+        let internalQueue = TestFactories.createInternalQueue()
 
-        // Test unsubscribing from within listener callback
-        emitter.on(signalledBy: controller.signal) { _, _ in
-            callCount += 1
-            controller.off() // Unsubscribe from within callback
+        internalQueue.ably_syncNoDeadlock {
+            let emitter = DefaultInternalEventEmitter<TestEvent, TestData>(internalQueue: internalQueue)
+            let controller = SubscriptionController(internalQueue: internalQueue)
+            let callCount = DispatchQueueMutex(dispatchQueue: internalQueue, initialValue: 0)
+
+            // Test unsubscribing from within listener callback
+            emitter.nosync_on(signalledBy: controller.signal) { _, _ in
+                callCount.withoutSync { $0 += 1 }
+                controller.nosync_off() // Unsubscribe from within callback
+            }
+
+            let testData = TestData(value: "test")
+            emitter.nosync_emit(event: .connect, data: testData)
+            #expect(callCount.withoutSync { $0 } == 1)
+
+            // Should not be called again
+            emitter.nosync_emit(event: .disconnect, data: testData)
+            #expect(callCount.withoutSync { $0 } == 1)
         }
-
-        let testData = TestData(value: "test")
-        emitter.emit(event: .connect, data: testData)
-        #expect(callCount == 1)
-
-        // Should not be called again
-        emitter.emit(event: .disconnect, data: testData)
-        #expect(callCount == 1)
     }
 
     @Test
-    func subscriptionControllerOffDoesNotAffectFutureSubscriptions() async throws {
-        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
-        let controller = SubscriptionController()
-        var firstCallCount = 0
-        var secondCallCount = 0
+    func subscriptionControllerOffDoesNotAffectFutureSubscriptions() {
+        let internalQueue = TestFactories.createInternalQueue()
 
-        // First subscription
-        emitter.on(signalledBy: controller.signal) { _, _ in
-            firstCallCount += 1
+        internalQueue.ably_syncNoDeadlock {
+            let emitter = DefaultInternalEventEmitter<TestEvent, TestData>(internalQueue: internalQueue)
+            let controller = SubscriptionController(internalQueue: internalQueue)
+            let firstCallCount = DispatchQueueMutex(dispatchQueue: internalQueue, initialValue: 0)
+            let secondCallCount = DispatchQueueMutex(dispatchQueue: internalQueue, initialValue: 0)
+
+            // First subscription
+            emitter.nosync_on(signalledBy: controller.signal) { _, _ in
+                firstCallCount.withoutSync { $0 += 1 }
+            }
+
+            let testData = TestData(value: "test")
+            emitter.nosync_emit(event: .connect, data: testData)
+            #expect(firstCallCount.withoutSync { $0 } == 1)
+
+            // Cancel first subscription
+            controller.nosync_off()
+
+            // Add another subscription with the same signal - should work
+            emitter.nosync_on(signalledBy: controller.signal) { _, _ in
+                secondCallCount.withoutSync { $0 += 1 }
+            }
+
+            emitter.nosync_emit(event: .disconnect, data: testData)
+            #expect(firstCallCount.withoutSync { $0 } == 1) // Should not increment
+            #expect(secondCallCount.withoutSync { $0 } == 1) // Should work despite previous nosync_off() call
         }
-
-        let testData = TestData(value: "test")
-        emitter.emit(event: .connect, data: testData)
-        #expect(firstCallCount == 1)
-
-        // Cancel first subscription
-        controller.off()
-
-        // Add another subscription with the same signal - should work
-        emitter.on(signalledBy: controller.signal) { _, _ in
-            secondCallCount += 1
-        }
-
-        emitter.emit(event: .disconnect, data: testData)
-        #expect(firstCallCount == 1) // Should not increment
-        #expect(secondCallCount == 1) // Should work despite previous off() call
     }
 
     @Test
-    func subscriptionContinuesAfterControllerDeallocation() async throws {
-        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
-        var callCount = 0
+    func subscriptionContinuesAfterControllerDeallocation() {
+        let internalQueue = TestFactories.createInternalQueue()
+        // `emitter` and `callCount` outlive the first `ably_syncNoDeadlock` block (they are
+        // also used by the second one), so they are created here rather than inside it.
+        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>(internalQueue: internalQueue)
+        let callCount = DispatchQueueMutex(dispatchQueue: internalQueue, initialValue: 0)
 
         // Create subscription with controller that will be deallocated
         weak var weakController: SubscriptionController?
-        do {
-            let controller = SubscriptionController()
+        internalQueue.ably_syncNoDeadlock {
+            let controller = SubscriptionController(internalQueue: internalQueue)
             weakController = controller
-            emitter.on(signalledBy: controller.signal) { _, _ in
-                callCount += 1
+            emitter.nosync_on(signalledBy: controller.signal) { _, _ in
+                callCount.withoutSync { $0 += 1 }
             }
 
             // Verify subscription works initially
             let testData = TestData(value: "test")
-            emitter.emit(event: .connect, data: testData)
-            #expect(callCount == 1)
+            emitter.nosync_emit(event: .connect, data: testData)
+            #expect(callCount.withoutSync { $0 } == 1)
 
             // Controller will be deallocated when leaving this scope
         }
@@ -473,104 +555,120 @@ struct DefaultInternalEventEmitterTests {
         precondition(weakController == nil)
 
         // Emit another value now that the controller has been deallocated
-        let testData = TestData(value: "test2")
-        emitter.emit(event: .disconnect, data: testData)
+        internalQueue.ably_syncNoDeadlock {
+            let testData = TestData(value: "test2")
+            emitter.nosync_emit(event: .disconnect, data: testData)
 
-        // The subscription should still work because listener registration is independent
-        // of controller lifetime - only calling off() should remove it
-        #expect(callCount == 2)
+            // The subscription should still work because listener registration is independent
+            // of controller lifetime - only calling nosync_off() should remove it
+            #expect(callCount.withoutSync { $0 } == 2)
+        }
     }
 
     // MARK: - Mixed Scenarios Tests
 
     @Test
-    func mixedOnAndOnceListeners() async throws {
-        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
-        var onCallCount = 0
-        var onceCallCount = 0
+    func mixedOnAndOnceListeners() {
+        let internalQueue = TestFactories.createInternalQueue()
 
-        emitter.on { _, _ in onCallCount += 1 }
-        emitter.once { _, _ in onceCallCount += 1 }
+        internalQueue.ably_syncNoDeadlock {
+            let emitter = DefaultInternalEventEmitter<TestEvent, TestData>(internalQueue: internalQueue)
+            let onCallCount = DispatchQueueMutex(dispatchQueue: internalQueue, initialValue: 0)
+            let onceCallCount = DispatchQueueMutex(dispatchQueue: internalQueue, initialValue: 0)
 
-        let testData = TestData(value: "test")
-        emitter.emit(event: .connect, data: testData)
-        #expect(onCallCount == 1)
-        #expect(onceCallCount == 1)
+            emitter.nosync_on { _, _ in onCallCount.withoutSync { $0 += 1 } }
+            emitter.nosync_once { _, _ in onceCallCount.withoutSync { $0 += 1 } }
 
-        emitter.emit(event: .disconnect, data: testData)
-        #expect(onCallCount == 2) // Should increment
-        #expect(onceCallCount == 1) // Should not increment
+            let testData = TestData(value: "test")
+            emitter.nosync_emit(event: .connect, data: testData)
+            #expect(onCallCount.withoutSync { $0 } == 1)
+            #expect(onceCallCount.withoutSync { $0 } == 1)
+
+            emitter.nosync_emit(event: .disconnect, data: testData)
+            #expect(onCallCount.withoutSync { $0 } == 2) // Should increment
+            #expect(onceCallCount.withoutSync { $0 } == 1) // Should not increment
+        }
     }
 
     @Test
-    func mixedAllEventAndNamedEventListeners() async throws {
-        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
-        var allEventCallCount = 0
-        var connectCallCount = 0
-        var disconnectCallCount = 0
+    func mixedAllEventAndNamedEventListeners() {
+        let internalQueue = TestFactories.createInternalQueue()
 
-        emitter.on { _, _ in allEventCallCount += 1 }
-        emitter.on(.connect) { _ in connectCallCount += 1 }
-        emitter.on(.disconnect) { _ in disconnectCallCount += 1 }
+        internalQueue.ably_syncNoDeadlock {
+            let emitter = DefaultInternalEventEmitter<TestEvent, TestData>(internalQueue: internalQueue)
+            let allEventCallCount = DispatchQueueMutex(dispatchQueue: internalQueue, initialValue: 0)
+            let connectCallCount = DispatchQueueMutex(dispatchQueue: internalQueue, initialValue: 0)
+            let disconnectCallCount = DispatchQueueMutex(dispatchQueue: internalQueue, initialValue: 0)
 
-        let testData = TestData(value: "test")
+            emitter.nosync_on { _, _ in allEventCallCount.withoutSync { $0 += 1 } }
+            emitter.nosync_on(.connect) { _ in connectCallCount.withoutSync { $0 += 1 } }
+            emitter.nosync_on(.disconnect) { _ in disconnectCallCount.withoutSync { $0 += 1 } }
 
-        emitter.emit(event: .connect, data: testData)
-        #expect(allEventCallCount == 1)
-        #expect(connectCallCount == 1)
-        #expect(disconnectCallCount == 0)
+            let testData = TestData(value: "test")
 
-        emitter.emit(event: .disconnect, data: testData)
-        #expect(allEventCallCount == 2)
-        #expect(connectCallCount == 1)
-        #expect(disconnectCallCount == 1)
+            emitter.nosync_emit(event: .connect, data: testData)
+            #expect(allEventCallCount.withoutSync { $0 } == 1)
+            #expect(connectCallCount.withoutSync { $0 } == 1)
+            #expect(disconnectCallCount.withoutSync { $0 } == 0)
 
-        emitter.emit(event: .message, data: testData)
-        #expect(allEventCallCount == 3)
-        #expect(connectCallCount == 1)
-        #expect(disconnectCallCount == 1)
+            emitter.nosync_emit(event: .disconnect, data: testData)
+            #expect(allEventCallCount.withoutSync { $0 } == 2)
+            #expect(connectCallCount.withoutSync { $0 } == 1)
+            #expect(disconnectCallCount.withoutSync { $0 } == 1)
+
+            emitter.nosync_emit(event: .message, data: testData)
+            #expect(allEventCallCount.withoutSync { $0 } == 3)
+            #expect(connectCallCount.withoutSync { $0 } == 1)
+            #expect(disconnectCallCount.withoutSync { $0 } == 1)
+        }
     }
 
     @Test
-    func complexScenario() async throws {
-        let emitter = DefaultInternalEventEmitter<TestEvent, TestData>()
-        let controller1 = SubscriptionController()
-        let controller2 = SubscriptionController()
-        var results: [String] = []
+    func complexScenario() {
+        let internalQueue = TestFactories.createInternalQueue()
 
-        // Mix of on/once, all-event/named-event, with/without signals
-        emitter.on { event, _ in results.append("all-on-\(event)") }
-        emitter.once { event, _ in results.append("all-once-\(event)") }
-        emitter.on(.connect) { _ in results.append("connect-on") }
-        emitter.once(.connect) { _ in results.append("connect-once") }
-        emitter.on(signalledBy: controller1.signal) { event, _ in results.append("signal1-\(event)") }
-        emitter.on(.connect, signalledBy: controller2.signal) { _ in results.append("connect-signal2") }
+        internalQueue.ably_syncNoDeadlock {
+            let emitter = DefaultInternalEventEmitter<TestEvent, TestData>(internalQueue: internalQueue)
+            let controller1 = SubscriptionController(internalQueue: internalQueue)
+            let controller2 = SubscriptionController(internalQueue: internalQueue)
+            let results = DispatchQueueMutex<[String]>(dispatchQueue: internalQueue, initialValue: [])
 
-        let testData = TestData(value: "test")
+            // Mix of on/once, all-event/named-event, with/without signals
+            emitter.nosync_on { event, _ in results.withoutSync { $0.append("all-on-\(event)") } }
+            emitter.nosync_once { event, _ in results.withoutSync { $0.append("all-once-\(event)") } }
+            emitter.nosync_on(.connect) { _ in results.withoutSync { $0.append("connect-on") } }
+            emitter.nosync_once(.connect) { _ in results.withoutSync { $0.append("connect-once") } }
+            emitter.nosync_on(signalledBy: controller1.signal) { event, _ in results.withoutSync { $0.append("signal1-\(event)") } }
+            emitter.nosync_on(.connect, signalledBy: controller2.signal) { _ in results.withoutSync { $0.append("connect-signal2") } }
 
-        // First emit
-        emitter.emit(event: .connect, data: testData)
-        #expect(results.count == 6)
-        #expect(results.contains("all-on-connect"))
-        #expect(results.contains("all-once-connect"))
-        #expect(results.contains("connect-on"))
-        #expect(results.contains("connect-once"))
-        #expect(results.contains("signal1-connect"))
-        #expect(results.contains("connect-signal2"))
+            let testData = TestData(value: "test")
 
-        results.removeAll()
+            // First emit
+            emitter.nosync_emit(event: .connect, data: testData)
+            let firstResults = results.withoutSync { $0 }
+            #expect(firstResults.count == 6)
+            #expect(firstResults.contains("all-on-connect"))
+            #expect(firstResults.contains("all-once-connect"))
+            #expect(firstResults.contains("connect-on"))
+            #expect(firstResults.contains("connect-once"))
+            #expect(firstResults.contains("signal1-connect"))
+            #expect(firstResults.contains("connect-signal2"))
 
-        // Cancel one signal
-        controller1.off()
+            results.withoutSync { $0.removeAll() }
 
-        // Second emit
-        emitter.emit(event: .connect, data: testData)
-        #expect(results.count == 3) // once listeners should not fire again, signal1 should not fire
-        #expect(results.contains("all-on-connect"))
-        #expect(results.contains("connect-on"))
-        #expect(results.contains("connect-signal2"))
-        #expect(!results.contains("all-once-connect"))
-        #expect(!results.contains("connect-once"))
-        #expect(!results.contains("signal1-connect"))
+            // Cancel one signal
+            controller1.nosync_off()
+
+            // Second emit
+            emitter.nosync_emit(event: .connect, data: testData)
+            let secondResults = results.withoutSync { $0 }
+            #expect(secondResults.count == 3) // once listeners should not fire again, signal1 should not fire
+            #expect(secondResults.contains("all-on-connect"))
+            #expect(secondResults.contains("connect-on"))
+            #expect(secondResults.contains("connect-signal2"))
+            #expect(!secondResults.contains("all-once-connect"))
+            #expect(!secondResults.contains("connect-once"))
+            #expect(!secondResults.contains("signal1-connect"))
+        }
     }
 }

--- a/Tests/AblyLiveObjectsTests/LiveObjectMutableStateTests.swift
+++ b/Tests/AblyLiveObjectsTests/LiveObjectMutableStateTests.swift
@@ -100,6 +100,7 @@ struct LiveObjectMutableStateTests {
         func canApplyOperation(testCase: TestCase) {
             let state = LiveObjectMutableState<Void>(
                 objectID: "test:object@123",
+                internalQueue: TestFactories.createInternalQueue(),
                 testsOnly_siteTimeserials: testCase.siteTimeserials,
             )
             let logger = TestLogger()
@@ -115,21 +116,19 @@ struct LiveObjectMutableStateTests {
     }
 
     struct SubscriptionTests {
-        // swiftlint:disable trailing_closure
-
         // @spec RTLO4b2
         @available(iOS 17.0.0, tvOS 17.0.0, *)
         @Test(arguments: [.detached, .failed] as [_AblyPluginSupportPrivate.RealtimeChannelState])
         func subscribeThrowsIfChannelIsDetachedOrFailed(channelState: _AblyPluginSupportPrivate.RealtimeChannelState) async throws {
-            var mutableState = LiveObjectMutableState<String>(objectID: "foo")
+            let internalQueue = TestFactories.createInternalQueue()
+            let mutableState = LiveObjectMutableState<String>(objectID: "foo", internalQueue: internalQueue)
             let queue = DispatchQueue.main
             let subscriber = Subscriber<String, SubscribeResponse>(callbackQueue: queue)
-            let internalQueue = TestFactories.createInternalQueue()
             let coreSDK = MockCoreSDK(channelState: channelState, internalQueue: internalQueue)
 
             #expect {
                 try internalQueue.ably_syncNoDeadlock {
-                    try mutableState.nosync_subscribe(listener: subscriber.createListener(), coreSDK: coreSDK, updateSelfLater: { _ in fatalError("Not expected") })
+                    try mutableState.nosync_subscribe(listener: subscriber.createListener(), coreSDK: coreSDK)
                 }
             } throws: { error in
                 guard let errorInfo = error as? ARTErrorInfo else {
@@ -146,17 +145,19 @@ struct LiveObjectMutableStateTests {
             @Test
             func noop() async throws {
                 // Given
-                var mutableState = LiveObjectMutableState<String>(objectID: "foo")
+                let internalQueue = TestFactories.createInternalQueue()
+                let mutableState = LiveObjectMutableState<String>(objectID: "foo", internalQueue: internalQueue)
                 let queue = DispatchQueue.main
                 let subscriber = Subscriber<String, SubscribeResponse>(callbackQueue: queue)
-                let internalQueue = TestFactories.createInternalQueue()
                 let coreSDK = MockCoreSDK(channelState: .attached, internalQueue: internalQueue)
                 try internalQueue.ably_syncNoDeadlock {
-                    _ = try mutableState.nosync_subscribe(listener: subscriber.createListener(), coreSDK: coreSDK, updateSelfLater: { _ in fatalError("Not expected") })
+                    _ = try mutableState.nosync_subscribe(listener: subscriber.createListener(), coreSDK: coreSDK)
                 }
 
                 // When
-                mutableState.emit(.noop, on: queue)
+                internalQueue.ably_syncNoDeadlock {
+                    mutableState.nosync_emit(.noop, on: queue)
+                }
 
                 // Then
                 let subscriberInvocations = await subscriber.getInvocations()
@@ -168,17 +169,19 @@ struct LiveObjectMutableStateTests {
             @Test
             func update() async throws {
                 // Given
-                var mutableState = LiveObjectMutableState<String>(objectID: "foo")
+                let internalQueue = TestFactories.createInternalQueue()
+                let mutableState = LiveObjectMutableState<String>(objectID: "foo", internalQueue: internalQueue)
                 let queue = DispatchQueue.main
                 let subscriber = Subscriber<String, SubscribeResponse>(callbackQueue: queue)
-                let internalQueue = TestFactories.createInternalQueue()
                 let coreSDK = MockCoreSDK(channelState: .attached, internalQueue: internalQueue)
                 try internalQueue.ably_syncNoDeadlock {
-                    _ = try mutableState.nosync_subscribe(listener: subscriber.createListener(), coreSDK: coreSDK, updateSelfLater: { _ in fatalError("Not expected") })
+                    _ = try mutableState.nosync_subscribe(listener: subscriber.createListener(), coreSDK: coreSDK)
                 }
 
                 // When
-                mutableState.emit(.update("bar"), on: queue)
+                internalQueue.ably_syncNoDeadlock {
+                    mutableState.nosync_emit(.update("bar"), on: queue)
+                }
 
                 // Then
                 let subscriberInvocations = await subscriber.getInvocations()
@@ -187,41 +190,6 @@ struct LiveObjectMutableStateTests {
         }
 
         struct UnsubscribeTests {
-            final class MutableStateStore<Update: Sendable>: Sendable {
-                private let mutex: DispatchQueueMutex<LiveObjectMutableState<Update>>
-
-                init(stored: LiveObjectMutableState<Update>, internalQueue: DispatchQueue) {
-                    mutex = .init(dispatchQueue: internalQueue, initialValue: stored)
-                }
-
-                @discardableResult
-                func subscribe(listener: @escaping LiveObjectUpdateCallback<Update>, coreSDK: CoreSDK) throws(ARTErrorInfo) -> SubscribeResponse {
-                    try mutex.withSync { stored throws(ARTErrorInfo) in
-                        try stored.nosync_subscribe(listener: listener, coreSDK: coreSDK, updateSelfLater: { [weak self] action in
-                            guard let self else {
-                                return
-                            }
-
-                            mutex.withSync { stored in
-                                action(&stored)
-                            }
-                        })
-                    }
-                }
-
-                func emit(_ update: LiveObjectUpdate<Update>, on queue: DispatchQueue) {
-                    mutex.withSync { stored in
-                        stored.emit(update, on: queue)
-                    }
-                }
-
-                func unsubscribeAll() {
-                    mutex.withSync { stored in
-                        stored.unsubscribeAll()
-                    }
-                }
-            }
-
             // @specOneOf(1/3) RTLO4b5b - Check we can unsubscribe using the response that's returned from `subscribe`
             @available(iOS 17.0.0, tvOS 17.0.0, *)
             @Test
@@ -229,15 +197,17 @@ struct LiveObjectMutableStateTests {
                 // Given
                 let queue = DispatchQueue.main
                 let internalQueue = TestFactories.createInternalQueue()
-                let store = MutableStateStore<String>(stored: .init(objectID: "foo"), internalQueue: internalQueue)
+                let mutableState = LiveObjectMutableState<String>(objectID: "foo", internalQueue: internalQueue)
                 let subscriber = Subscriber<String, SubscribeResponse>(callbackQueue: queue)
                 let coreSDK = MockCoreSDK(channelState: .attached, internalQueue: internalQueue)
-                let subscription = try store.subscribe(listener: subscriber.createListener(), coreSDK: coreSDK)
+                let subscription = try internalQueue.ably_syncNoDeadlock {
+                    try mutableState.nosync_subscribe(listener: subscriber.createListener(), coreSDK: coreSDK)
+                }
 
                 // When
-                store.emit(.update("bar"), on: queue)
+                internalQueue.ably_syncNoDeadlock { mutableState.nosync_emit(.update("bar"), on: queue) }
                 subscription.unsubscribe()
-                store.emit(.update("baz"), on: queue)
+                internalQueue.ably_syncNoDeadlock { mutableState.nosync_emit(.update("baz"), on: queue) }
 
                 // Then
                 let subscriberInvocations = await subscriber.getInvocations()
@@ -251,18 +221,22 @@ struct LiveObjectMutableStateTests {
                 // Given
                 let queue = DispatchQueue.main
                 let internalQueue = TestFactories.createInternalQueue()
-                let store = MutableStateStore<String>(stored: .init(objectID: "foo"), internalQueue: internalQueue)
+                let mutableState = LiveObjectMutableState<String>(objectID: "foo", internalQueue: internalQueue)
                 let subscriber = Subscriber<String, SubscribeResponse>(callbackQueue: queue)
                 let coreSDK = MockCoreSDK(channelState: .attached, internalQueue: internalQueue)
                 // Create a listener that calls `unsubscribe` on the `response` that's passed to the listener
                 let listener = subscriber.createListener { _, response in
                     response.unsubscribe()
                 }
-                try store.subscribe(listener: listener, coreSDK: coreSDK)
+                try internalQueue.ably_syncNoDeadlock {
+                    _ = try mutableState.nosync_subscribe(listener: listener, coreSDK: coreSDK)
+                }
 
                 // When
-                store.emit(.update("bar"), on: queue)
-                store.emit(.update("baz"), on: queue)
+                internalQueue.ably_syncNoDeadlock {
+                    mutableState.nosync_emit(.update("bar"), on: queue)
+                    mutableState.nosync_emit(.update("baz"), on: queue)
+                }
 
                 // Then
                 let subscriberInvocations = await subscriber.getInvocations()
@@ -277,20 +251,22 @@ struct LiveObjectMutableStateTests {
                 // Given
                 let queue = DispatchQueue.main
                 let internalQueue = TestFactories.createInternalQueue()
-                let store = MutableStateStore<String>(stored: .init(objectID: "foo"), internalQueue: internalQueue)
+                let mutableState = LiveObjectMutableState<String>(objectID: "foo", internalQueue: internalQueue)
                 let subscriber = Subscriber<String, SubscribeResponse>(callbackQueue: queue)
                 let coreSDK = MockCoreSDK(channelState: .attached, internalQueue: internalQueue)
                 // Create a listener that calls `unsubscribe` on the `response` that's passed to the listener
                 let listener = subscriber.createListener { _, response in
                     response.unsubscribe()
                 }
-                try store.subscribe(listener: listener, coreSDK: coreSDK)
+                try internalQueue.ably_syncNoDeadlock {
+                    _ = try mutableState.nosync_subscribe(listener: listener, coreSDK: coreSDK)
+                }
 
                 // When
-                store.emit(.update("bar"), on: queue)
+                internalQueue.ably_syncNoDeadlock { mutableState.nosync_emit(.update("bar"), on: queue) }
                 // This is what distinguishes us from the previous test; the updates aren't back to back
                 _ = await subscriber.getInvocations()
-                store.emit(.update("baz"), on: queue)
+                internalQueue.ably_syncNoDeadlock { mutableState.nosync_emit(.update("baz"), on: queue) }
 
                 // Then
                 let subscriberInvocations = await subscriber.getInvocations()
@@ -304,20 +280,24 @@ struct LiveObjectMutableStateTests {
                 // Given
                 let queue = DispatchQueue.main
                 let internalQueue = TestFactories.createInternalQueue()
-                let store = MutableStateStore<String>(stored: .init(objectID: "foo"), internalQueue: internalQueue)
+                let mutableState = LiveObjectMutableState<String>(objectID: "foo", internalQueue: internalQueue)
                 let coreSDK = MockCoreSDK(channelState: .attached, internalQueue: internalQueue)
                 let subscribers: [Subscriber<String, SubscribeResponse>] = [
                     .init(callbackQueue: queue),
                     .init(callbackQueue: queue),
                 ]
-                for subscriber in subscribers {
-                    try store.subscribe(listener: subscriber.createListener(), coreSDK: coreSDK)
+                try internalQueue.ably_syncNoDeadlock {
+                    for subscriber in subscribers {
+                        _ = try mutableState.nosync_subscribe(listener: subscriber.createListener(), coreSDK: coreSDK)
+                    }
                 }
 
                 // When
-                store.emit(.update("bar"), on: queue)
-                store.unsubscribeAll()
-                store.emit(.update("baz"), on: queue)
+                internalQueue.ably_syncNoDeadlock {
+                    mutableState.nosync_emit(.update("bar"), on: queue)
+                    mutableState.nosync_unsubscribeAll()
+                    mutableState.nosync_emit(.update("baz"), on: queue)
+                }
 
                 // Then
                 for subscriber in subscribers {
@@ -326,7 +306,5 @@ struct LiveObjectMutableStateTests {
                 }
             }
         }
-
-        // swiftlint:enable trailing_closure
     }
 }


### PR DESCRIPTION
Removes the complicated `updateSelfLater` mutable state pattern and just wraps a `EventEmitter` class instead. No public API changes. See commit messages for more details.

Resolves #102.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Redesigned event subscription and listener handling for more consistent, reliable live-object event delivery and lifecycle signaling.

* **Behavior**
  * Live map, counter, and realtime object updates now use the new synchronous-safe emission paths for more predictable update dispatch to callbacks.

* **Tests**
  * Added extensive tests covering event registration, one-time listeners, signal-based cancellation, and emission stability during callbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->