### PR TITLE
  ci: GitHub Actions workflow security cleanup

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -162,10 +162,14 @@ jobs:
       # We run these as two separate steps so that we can easily see the execution time of each step.
 
       - name: Build for testing
-        run: swift run BuildTool build-library-for-testing --platform ${{ matrix.platform }}
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: swift run BuildTool build-library-for-testing --platform "$PLATFORM"
 
       - name: Run tests
-        run: swift run BuildTool test-library --platform ${{ matrix.platform }} --without-building
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: swift run BuildTool test-library --platform "$PLATFORM" --without-building
 
   code-coverage:
     name: Generate code coverage
@@ -227,7 +231,9 @@ jobs:
           xcode-version: ${{ matrix.tooling.xcodeVersion }}
 
       - name: Build library
-        run: swift run BuildTool build-library --platform ${{ matrix.platform }} --configuration release
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: swift run BuildTool build-library --platform "$PLATFORM" --configuration release
 
   check-example-app:
     name: Example app, ${{matrix.platform}} (Xcode ${{ matrix.tooling.xcodeVersion }})
@@ -251,7 +257,9 @@ jobs:
           xcode-version: ${{ matrix.tooling.xcodeVersion }}
 
       - name: Build example app
-        run: swift run BuildTool build-example-app --platform ${{ matrix.platform }}
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: swift run BuildTool build-example-app --platform "$PLATFORM"
 
   check-documentation:
     runs-on: macos-15
@@ -284,9 +292,11 @@ jobs:
 
       # Build the documentation using Swift DocC
       - name: Build documentation
+        env:
+          HOSTING_BASE_PATH: ${{ steps.preupload.outputs.base-path }}
         run: |
           swift package generate-documentation --target AblyLiveObjects --disable-indexing \
-          --hosting-base-path "${{ steps.preupload.outputs.base-path }}" \
+          --hosting-base-path "$HOSTING_BASE_PATH" \
           --transform-for-static-hosting
         working-directory: ${{ github.workspace }}
 

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -18,6 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           submodules: true
 
       # This step can be removed once the runners' default version of Xcode is 16.4 or above
@@ -47,6 +48,7 @@ jobs:
   #    steps:
   #      - uses: actions/checkout@v4
   #        with:
+  #          persist-credentials: false
   #          submodules: true
   #
   #      # This step can be removed once the runners' default version of Xcode is 16.4 or above
@@ -66,6 +68,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           submodules: true
 
       # This step can be removed once the runners' default version of Xcode is 16.4 or above
@@ -87,6 +90,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           submodules: true
       - uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -107,6 +111,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           submodules: true
       - uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -127,6 +132,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           submodules: true
       - uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -147,6 +153,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           submodules: true
 
       # This step can be removed once the runners' default version of Xcode is 16.4 or above
@@ -185,6 +192,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           submodules: true
       - uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -205,6 +213,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           submodules: true
       - uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -224,6 +233,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           submodules: true
 
       # This step can be removed once the runners' default version of Xcode is 16.4 or above

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -22,19 +22,19 @@ jobs:
       MINT_LINK_PATH: .mint/bin
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
           submodules: true
 
       # This step can be removed once the runners' default version of Xcode is 16.4 or above
-      - uses: maxim-lobanov/setup-xcode@v1
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
           xcode-version: 16.4
 
       # We use caching for Mint because at the time of writing SwiftLint took about 5 minutes to build in CI, which is unacceptably slow.
       # https://github.com/actions/cache/blob/40c3b67b2955d93d83b27ed164edd0756bc24049/examples.md#swift---mint
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .mint
           key: ${{ runner.os }}-mint-${{ hashFiles('**/Mintfile') }}
@@ -52,13 +52,13 @@ jobs:
   #  spec-coverage:
   #    runs-on: macos-15
   #    steps:
-  #      - uses: actions/checkout@v4
+  #      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
   #        with:
   #          persist-credentials: false
   #          submodules: true
   #
   #      # This step can be removed once the runners' default version of Xcode is 16.4 or above
-  #      - uses: maxim-lobanov/setup-xcode@v1
+  #      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
   #        with:
   #          xcode-version: 16.4
   #
@@ -76,13 +76,13 @@ jobs:
     outputs:
       matrix: ${{ steps.generation-step.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
           submodules: true
 
       # This step can be removed once the runners' default version of Xcode is 16.4 or above
-      - uses: maxim-lobanov/setup-xcode@v1
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
           xcode-version: 16.4
 
@@ -102,11 +102,11 @@ jobs:
       matrix: ${{ fromJson(needs.generate-matrices.outputs.matrix).withoutPlatform }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
           submodules: true
-      - uses: maxim-lobanov/setup-xcode@v1
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
           xcode-version: ${{ matrix.tooling.xcodeVersion }}
 
@@ -127,11 +127,11 @@ jobs:
       matrix: ${{ fromJson(needs.generate-matrices.outputs.matrix).withoutPlatform }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
           submodules: true
-      - uses: maxim-lobanov/setup-xcode@v1
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
           xcode-version: ${{ matrix.tooling.xcodeVersion }}
 
@@ -151,11 +151,11 @@ jobs:
       matrix: ${{ fromJson(needs.generate-matrices.outputs.matrix).withPlatform }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
           submodules: true
-      - uses: maxim-lobanov/setup-xcode@v1
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
           xcode-version: ${{ matrix.tooling.xcodeVersion }}
 
@@ -180,13 +180,13 @@ jobs:
       checks: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
           submodules: true
 
       # This step can be removed once the runners' default version of Xcode is 16.4 or above
-      - uses: maxim-lobanov/setup-xcode@v1
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
           xcode-version: 16.4
 
@@ -200,7 +200,7 @@ jobs:
       # - offer more fine-grained configuration about which data to include in the report (I only care about code coverage, not test results, and I don't care about code coverage of the AblyLiveObjectsTests target)
       #
       # but it'll do for now (we can always fork or have another look for tooling later).
-      - uses: slidoapp/xcresulttool@v3.1.0
+      - uses: slidoapp/xcresulttool@9c51e32ae0320e0ca9b63240e4da8e974ac573e3 # v3.1.0
         with:
           path: CodeCoverage.xcresult
           # This title will be used for the sidebar item that this job adds to GitHub results page for this workflow
@@ -222,11 +222,11 @@ jobs:
       matrix: ${{ fromJson(needs.generate-matrices.outputs.matrix).withPlatform }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
           submodules: true
-      - uses: maxim-lobanov/setup-xcode@v1
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
           xcode-version: ${{ matrix.tooling.xcodeVersion }}
 
@@ -248,11 +248,11 @@ jobs:
       matrix: ${{ fromJson(needs.generate-matrices.outputs.matrix).withPlatform }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
           submodules: true
-      - uses: maxim-lobanov/setup-xcode@v1
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
           xcode-version: ${{ matrix.tooling.xcodeVersion }}
 
@@ -270,20 +270,20 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
           submodules: true
 
       # This step can be removed once the runners' default version of Xcode is 16.4 or above
-      - uses: maxim-lobanov/setup-xcode@v1
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
           xcode-version: 16.4
 
       # Dry run upload-action to get base-path url
       - name: Dry-Run Upload (to get url)
         id: preupload
-        uses: ably/sdk-upload-action@v2
+        uses: ably/sdk-upload-action@4e694297f208b72b5a9f6b1248a1556f19f821d6 # v2
         with:
           mode: preempt
           sourcePath: .build/plugins/Swift-DocC/outputs/AblyLiveObjects.doccarchive # Path to the Swift DocC output folder
@@ -302,7 +302,7 @@ jobs:
 
       # Configure AWS credentials for uploading documentation
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           aws-region: eu-west-2
           role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/ably-sdk-builds-ably-liveobjects-swift-plugin
@@ -310,7 +310,7 @@ jobs:
 
       # Upload the generated documentation
       - name: Upload Documentation
-        uses: ably/sdk-upload-action@v2
+        uses: ably/sdk-upload-action@4e694297f208b72b5a9f6b1248a1556f19f821d6 # v2
         with:
           sourcePath: .build/plugins/Swift-DocC/outputs/AblyLiveObjects.doccarchive # Path to the Swift DocC output folder
           githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -6,9 +6,15 @@ on:
   push:
     branches:
       - main
+
+permissions: {}
+
 jobs:
   lint:
     runs-on: macos-15
+
+    permissions:
+      contents: read
 
     # From actions/cache documentation linked to below
     env:
@@ -63,6 +69,10 @@ jobs:
 
   generate-matrices:
     runs-on: macos-15
+
+    permissions:
+      contents: read
+
     outputs:
       matrix: ${{ steps.generation-step.outputs.matrix }}
     steps:
@@ -83,6 +93,10 @@ jobs:
     name: SPM (Xcode ${{ matrix.tooling.xcodeVersion }})
     runs-on: macos-15
     needs: generate-matrices
+
+    permissions:
+      contents: read
+
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.generate-matrices.outputs.matrix).withoutPlatform }}
@@ -104,6 +118,10 @@ jobs:
     name: SPM, `release` configuration (Xcode ${{ matrix.tooling.xcodeVersion }})
     runs-on: macos-15
     needs: generate-matrices
+
+    permissions:
+      contents: read
+
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.generate-matrices.outputs.matrix).withoutPlatform }}
@@ -124,6 +142,9 @@ jobs:
     name: Xcode, ${{matrix.platform}} (Xcode ${{ matrix.tooling.xcodeVersion }})
     runs-on: macos-15
     needs: generate-matrices
+
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false
@@ -149,6 +170,10 @@ jobs:
   code-coverage:
     name: Generate code coverage
     runs-on: macos-15
+
+    permissions:
+      contents: read
+      checks: write
 
     steps:
       - uses: actions/checkout@v4
@@ -185,6 +210,9 @@ jobs:
     runs-on: macos-15
     needs: generate-matrices
 
+    permissions:
+      contents: read
+
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.generate-matrices.outputs.matrix).withPlatform }}
@@ -205,6 +233,9 @@ jobs:
     name: Example app, ${{matrix.platform}} (Xcode ${{ matrix.tooling.xcodeVersion }})
     runs-on: macos-15
     needs: generate-matrices
+
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false
@@ -283,6 +314,9 @@ jobs:
   # tweak the matrices).
   all-checks-completed:
     runs-on: ubuntu-latest
+
+    permissions: {}
+
     needs:
       - lint
       # - spec-coverage


### PR DESCRIPTION
Routine hygiene pass over the GitHub Actions workflow in this repo, addressing findings from a workflow security audit. Changes are split into four commits, one per finding type:

  - Disable credential persistence on `actions/checkout` steps so the default `GITHUB_TOKEN` is not left in the local git config after checkout.
  - Scope each job's permissions explicitly: top-level `permissions: {}`, with each job granted only the `GITHUB_TOKEN` scopes it actually needs.
  - Move workflow-context expansions (`${{ matrix.platform }}`, step outputs) out of `run:` shell source and into `env:` bindings.
  - Pin all third-party actions to commit SHAs (with the tag preserved as a comment) so an upstream tag move can't silently change what runs in CI.

  No behavioural changes intended — the workflow runs the same checks against the same inputs.